### PR TITLE
Add a CLI argument for not showing the spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ If either required flag is omitted the CLI will prompt you for the inputs.
 
 If you don't supply an input file, and the CLI is able to detect a package.json in the folder you run the command from, then it will allow you to run the command using the detected file.
 
+To disable the spinner which appears in the terminal while the file is being generated you can also pass in the `--no-spinner` flag.
+
 ## Installation and Usage (Programmatic use)
 
 ```

--- a/src/cli/args/no-spinner.ts
+++ b/src/cli/args/no-spinner.ts
@@ -1,0 +1,10 @@
+import { Result } from "arg";
+import { ArgumentsWithAliases } from "../cli-arguments";
+import { Argument } from "./argument";
+
+export class NoSpinner extends Argument<boolean> {
+  public resolve(args: Result<ArgumentsWithAliases>): Promise<boolean> {
+    const inputtedNoSpinner = args["--no-spinner"];
+    return Promise.resolve(inputtedNoSpinner ?? false);
+  }
+}

--- a/src/cli/cli-arguments.ts
+++ b/src/cli/cli-arguments.ts
@@ -8,12 +8,14 @@ export interface UserInputs {
   output?: string;
   overwriteOutput?: boolean;
   eol?: string;
+  noSpinner?: boolean;
 }
 
 export interface CliOptions {
   input: string;
   output: string;
   eol?: LineEnding;
+  noSpinner: boolean;
 }
 
 export interface ArgumentsWithAliases extends Spec {
@@ -21,6 +23,7 @@ export interface ArgumentsWithAliases extends Spec {
   "--output": typeof String;
   "--overwrite": typeof Boolean;
   "--eol": typeof String;
+  "--no-spinner": typeof Boolean;
   "-i": "--input";
   "-o": "--output";
 }
@@ -30,6 +33,7 @@ export const argumentsWithAliases: ArgumentsWithAliases = {
   "--output": String,
   "--overwrite": Boolean,
   "--eol": String,
+  "--no-spinner": Boolean,
   "-i": "--input",
   "-o": "--output"
 };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,18 +2,21 @@ import arg, { Result } from "arg";
 import { generateLicenseFile } from "../generateLicenseFile";
 import { Eol } from "./args/eol";
 import { Input } from "./args/input";
+import { NoSpinner } from "./args/no-spinner";
 import { Output } from "./args/output";
 import { ArgumentsWithAliases, argumentsWithAliases, CliOptions } from "./cli-arguments";
 import { spinner } from "./spinner";
 
 export async function cli(args: string[]): Promise<void> {
   const givenUserInputs = parseUserInputs(args);
-  const cliOptions: CliOptions = await promptForMissingOptions(givenUserInputs);
+  const { input, output, eol, noSpinner } = await promptForMissingOptions(givenUserInputs);
 
-  spinner.start();
+  if (!noSpinner) {
+    spinner.start();
+  }
 
   try {
-    await generateLicenseFile(cliOptions.input, cliOptions.output, cliOptions.eol);
+    await generateLicenseFile(input, output, eol);
     spinner.stop();
   } catch (e) {
     spinner.fail(e?.message ?? e ?? "Unknown error");
@@ -30,6 +33,7 @@ async function promptForMissingOptions(options: Result<ArgumentsWithAliases>): P
   const input = await new Input().resolve(options);
   const output = await new Output().resolve(options);
   const eol = await new Eol().resolve(options);
+  const noSpinner = await new NoSpinner().resolve(options);
 
-  return { input, output, eol };
+  return { input, output, eol, noSpinner };
 }

--- a/test/cli/args/no-spinner.spec.ts
+++ b/test/cli/args/no-spinner.spec.ts
@@ -1,0 +1,34 @@
+import { Result } from "arg";
+import { NoSpinner } from "../../../src/cli/args/no-spinner";
+import { ArgumentsWithAliases } from "../../../src/cli/cli-arguments";
+
+describe("NoSpinner", () => {
+  describe("resolve", () => {
+    [
+      { input: true, expected: true },
+      { input: false, expected: false },
+      { input: undefined, expected: false },
+      { input: null, expected: false }
+    ].forEach(({ input, expected }) =>
+      it(`should return ${expected} when the --no-spinner arg is ${input}`, async () => {
+        const noSpinner = new NoSpinner();
+
+        const args = {
+          "--no-spinner": input
+        } as Result<ArgumentsWithAliases>;
+
+        const result = await noSpinner.resolve(args);
+        return expect(result).toBe(expected);
+      })
+    );
+
+    it(`should return false when the --no-spinner arg is not given`, async () => {
+      const noSpinner = new NoSpinner();
+
+      const args = {} as Result<ArgumentsWithAliases>;
+
+      const result = await noSpinner.resolve(args);
+      return expect(result).toBe(false);
+    });
+  });
+});

--- a/test/cli/index.spec.ts
+++ b/test/cli/index.spec.ts
@@ -135,10 +135,18 @@ describe("cli", () => {
     });
   });
 
-  it("should start the spinner", async () => {
+  it("should start the spinner if noSpinner is false", async () => {
     await cli(["", "", "--input", "any input path", "--output", "any output path"]);
 
     expect(mockedStartSpinner).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not start the spinner if noSpinner is true", async () => {
+    mockNoSpinner.mockReturnValue(true);
+
+    await cli(["", "", "--input", "any input path", "--output", "any output path"]);
+
+    expect(mockedStartSpinner).toHaveBeenCalledTimes(0);
   });
 
   it("should call generateLicenseFile with value from the input resolver", async () => {

--- a/test/cli/index.spec.ts
+++ b/test/cli/index.spec.ts
@@ -22,6 +22,7 @@ jest.mock("../../src/cli/spinner", () => ({
 const mockInputResolve = jest.fn();
 const mockOutputResolve = jest.fn();
 const mockEolResolve = jest.fn();
+const mockNoSpinner = jest.fn();
 
 jest.mock("../../src/cli/args/input.ts", () => ({
   Input: function () {
@@ -38,6 +39,12 @@ jest.mock("../../src/cli/args/output.ts", () => ({
 jest.mock("../../src/cli/args/eol.ts", () => ({
   Eol: function () {
     return { resolve: mockEolResolve };
+  }
+}));
+
+jest.mock("../../src/cli/args/no-spinner.ts", () => ({
+  NoSpinner: function () {
+    return { resolve: mockNoSpinner };
   }
 }));
 


### PR DESCRIPTION
- `spinner.fail("message")` still works for showing failure reasons