### PR TITLE
Implement --ci flag

### DIFF
--- a/src/cli/args/argument.ts
+++ b/src/cli/args/argument.ts
@@ -7,6 +7,7 @@ export type MultipleChoiceOptions<T> = {
 };
 
 export abstract class Argument<T> {
+  abstract parse(args: Result<ArgumentsWithAliases>): Promise<T>;
   abstract resolve(args: Result<ArgumentsWithAliases>): Promise<T>;
 
   protected async promptForString(question: string, initialValue: string): Promise<string> {

--- a/src/cli/args/eol.ts
+++ b/src/cli/args/eol.ts
@@ -24,4 +24,16 @@ export class Eol extends Argument<LineEnding | undefined> {
 
     return answer;
   }
+
+  public async parse(args: Result<ArgumentsWithAliases>): Promise<LineEnding | undefined> {
+    const eol = args["--eol"];
+
+    if (!isValidEol(eol)) {
+      throw new Error(
+        `Invalid line ending given: '${eol}'. Possible values are 'windows', 'posix'. Omit the --eol flag to use the system default.`
+      );
+    }
+
+    return eol;
+  }
 }

--- a/src/cli/args/input.ts
+++ b/src/cli/args/input.ts
@@ -25,6 +25,22 @@ export class Input extends Argument<string> {
     return input;
   }
 
+  public async parse(args: Result<ArgumentsWithAliases>): Promise<string> {
+    const input = args["--input"];
+
+    if (!input) {
+      throw new Error("No --input argument given.");
+    }
+
+    const inputExists = await doesFileExist(input);
+
+    if (!inputExists) {
+      throw new Error(`Given --input file not found. Cannot find '${input}'.`);
+    }
+
+    return input;
+  }
+
   private async getInitialValue(): Promise<string> {
     const packageJsonExists = await doesFileExist("./package.json");
     return packageJsonExists ? "./package.json" : "";

--- a/src/cli/args/no-spinner.ts
+++ b/src/cli/args/no-spinner.ts
@@ -7,4 +7,9 @@ export class NoSpinner extends Argument<boolean> {
     const inputtedNoSpinner = args["--no-spinner"];
     return Promise.resolve(inputtedNoSpinner ?? false);
   }
+
+  public parse(args: Result<ArgumentsWithAliases>): Promise<boolean> {
+    const inputtedNoSpinner = args["--no-spinner"];
+    return Promise.resolve(inputtedNoSpinner ?? false);
+  }
 }

--- a/src/cli/args/output.ts
+++ b/src/cli/args/output.ts
@@ -34,4 +34,23 @@ export class Output extends Argument<string> {
 
     return output;
   }
+
+  public async parse(args: Result<ArgumentsWithAliases>): Promise<string> {
+    const output = args["--output"];
+    const allowOverwrite = args["--overwrite"];
+
+    if (!output) {
+      throw new Error("No --output argument given.");
+    }
+
+    const outputExists = await doesFileExist(output);
+
+    if (outputExists && !allowOverwrite) {
+      throw new Error(
+        `Given --output file already exists at '${output}'. Use --overwrite to allow overwriting.`
+      );
+    }
+
+    return output;
+  }
 }

--- a/src/cli/cli-arguments.ts
+++ b/src/cli/cli-arguments.ts
@@ -9,6 +9,7 @@ export interface UserInputs {
   overwriteOutput?: boolean;
   eol?: string;
   noSpinner?: boolean;
+  ci?: boolean;
 }
 
 export interface CliOptions {
@@ -24,6 +25,7 @@ export interface ArgumentsWithAliases extends Spec {
   "--overwrite": typeof Boolean;
   "--eol": typeof String;
   "--no-spinner": typeof Boolean;
+  "--ci": typeof Boolean;
   "-i": "--input";
   "-o": "--output";
 }
@@ -34,6 +36,7 @@ export const argumentsWithAliases: ArgumentsWithAliases = {
   "--overwrite": Boolean,
   "--eol": String,
   "--no-spinner": Boolean,
+  "--ci": Boolean,
   "-i": "--input",
   "-o": "--output"
 };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,12 +12,14 @@ export async function main(args: string[]): Promise<void> {
     await cli(args);
   } catch (e) {
     spinner.fail(e?.message ?? e ?? "Unknown error");
+    process.exitCode = 1;
   }
 }
 
 async function cli(args: string[]) {
   const givenUserInputs = parseUserInputs(args);
-  const { input, output, eol, noSpinner } = await promptForMissingOptions(givenUserInputs);
+
+  const { input, output, eol, noSpinner } = await parseArgumentsIntoOptions(givenUserInputs);
 
   if (!noSpinner) {
     spinner.start();
@@ -31,6 +33,31 @@ function parseUserInputs(rawArgs: string[]): Result<ArgumentsWithAliases> {
   return arg(argumentsWithAliases, {
     argv: rawArgs.slice(2)
   });
+}
+
+async function parseArgumentsIntoOptions(args: Result<ArgumentsWithAliases>): Promise<CliOptions> {
+  const isCi = args["--ci"];
+
+  if (isCi) {
+    args["--no-spinner"] = true;
+
+    try {
+      return await getOptionsOrThrow(args);
+    } catch (e) {
+      throw new Error(`Error parsing arguments in --ci mode: ${e?.message ?? e}`);
+    }
+  }
+
+  return await promptForMissingOptions(args);
+}
+
+async function getOptionsOrThrow(options: Result<ArgumentsWithAliases>): Promise<CliOptions> {
+  const input = await new Input().parse(options);
+  const output = await new Output().parse(options);
+  const eol = await new Eol().parse(options);
+  const noSpinner = await new NoSpinner().parse(options);
+
+  return { input, output, eol, noSpinner };
 }
 
 async function promptForMissingOptions(options: Result<ArgumentsWithAliases>): Promise<CliOptions> {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,7 +44,7 @@ async function parseArgumentsIntoOptions(args: Result<ArgumentsWithAliases>): Pr
     try {
       return await getOptionsOrThrow(args);
     } catch (e) {
-      throw new Error(`Error parsing arguments in --ci mode: ${e?.message ?? e}`);
+      throw new Error(`Error parsing arguments in --ci mode: ${e.message}`);
     }
   }
 

--- a/test/cli/args/eol.spec.ts
+++ b/test/cli/args/eol.spec.ts
@@ -23,119 +23,161 @@ describe("Eol", () => {
     jest.restoreAllMocks();
   });
 
-  it("should return undefined if '--eol' is undefined", async () => {
-    const args = {} as Result<ArgumentsWithAliases>;
+  describe("resolve", () => {
+    it("should return undefined if '--eol' is undefined", async () => {
+      const args = {} as Result<ArgumentsWithAliases>;
 
-    const answer = await eol.resolve(args);
+      const answer = await eol.resolve(args);
 
-    expect(answer).toBeUndefined();
-  });
-
-  it("should return 'windows' if '--eol' is 'windows'", async () => {
-    const args = {
-      "--eol": "windows"
-    } as Result<ArgumentsWithAliases>;
-
-    const answer = await eol.resolve(args);
-
-    expect(answer).toBe("windows");
-  });
-
-  it("should return 'posix' if '--eol' is 'posix'", async () => {
-    const args = {
-      "--eol": "posix"
-    } as Result<ArgumentsWithAliases>;
-
-    const answer = await eol.resolve(args);
-
-    expect(answer).toBe("posix");
-  });
-
-  it("should prompt the user for a valid answer if an invalid line ending value is provided", async () => {
-    mockedPrompt.mockResolvedValue({
-      value: "dummy value"
+      expect(answer).toBeUndefined();
     });
 
-    const args = {
-      "--eol": "test"
-    } as Result<ArgumentsWithAliases>;
-
-    await eol.resolve(args);
-
-    expect(mockedPrompt).toBeCalledTimes(1);
-  });
-
-  it("should prompt the user with a multiple choice prompt if an invalid line ending value is provided", async () => {
-    mockedPrompt.mockResolvedValue({
-      value: "dummy value"
-    });
-
-    const args = {
-      "--eol": "test"
-    } as Result<ArgumentsWithAliases>;
-
-    await eol.resolve(args);
-
-    expect(mockedPrompt).toBeCalledWith(
-      expect.objectContaining({
-        type: "select"
-      })
-    );
-  });
-
-  it("should prompt the user with a multiple choice prompt containing valid options if an invalid line ending value is provided", async () => {
-    mockedPrompt.mockResolvedValue({
-      value: "dummy value"
-    });
-
-    const args = {
-      "--eol": "test"
-    } as Result<ArgumentsWithAliases>;
-
-    await eol.resolve(args);
-
-    expect(mockedPrompt).toBeCalledWith(
-      expect.objectContaining({
-        choices: ["Windows", "POSIX", "System default"]
-      })
-    );
-  });
-
-  it("should prompt the user with a message if an invalid line ending value is provided", async () => {
-    mockedPrompt.mockResolvedValue({
-      value: "dummy value"
-    });
-
-    const args = {
-      "--eol": "test"
-    } as Result<ArgumentsWithAliases>;
-
-    await eol.resolve(args);
-
-    expect(mockedPrompt).toBeCalledWith(
-      expect.objectContaining({
-        message: "Invalid line ending given. Please choose a line ending: "
-      })
-    );
-  });
-
-  [
-    { key: "Windows", value: "windows" },
-    { key: "POSIX", value: "posix" },
-    { key: "System default", value: undefined }
-  ].forEach(testCase =>
-    it(`should return ${testCase.value} if the user selects ${testCase.key} from the multiple choice prompt`, async () => {
-      mockedPrompt.mockResolvedValue({
-        value: testCase.key
-      });
-
+    it("should return 'windows' if '--eol' is 'windows'", async () => {
       const args = {
-        "--eol": testCase.key
+        "--eol": "windows"
       } as Result<ArgumentsWithAliases>;
 
       const answer = await eol.resolve(args);
 
-      expect(answer).toBe(testCase.value);
-    })
-  );
+      expect(answer).toBe("windows");
+    });
+
+    it("should return 'posix' if '--eol' is 'posix'", async () => {
+      const args = {
+        "--eol": "posix"
+      } as Result<ArgumentsWithAliases>;
+
+      const answer = await eol.resolve(args);
+
+      expect(answer).toBe("posix");
+    });
+
+    it("should prompt the user for a valid answer if an invalid line ending value is provided", async () => {
+      mockedPrompt.mockResolvedValue({
+        value: "dummy value"
+      });
+
+      const args = {
+        "--eol": "test"
+      } as Result<ArgumentsWithAliases>;
+
+      await eol.resolve(args);
+
+      expect(mockedPrompt).toBeCalledTimes(1);
+    });
+
+    it("should prompt the user with a multiple choice prompt if an invalid line ending value is provided", async () => {
+      mockedPrompt.mockResolvedValue({
+        value: "dummy value"
+      });
+
+      const args = {
+        "--eol": "test"
+      } as Result<ArgumentsWithAliases>;
+
+      await eol.resolve(args);
+
+      expect(mockedPrompt).toBeCalledWith(
+        expect.objectContaining({
+          type: "select"
+        })
+      );
+    });
+
+    it("should prompt the user with a multiple choice prompt containing valid options if an invalid line ending value is provided", async () => {
+      mockedPrompt.mockResolvedValue({
+        value: "dummy value"
+      });
+
+      const args = {
+        "--eol": "test"
+      } as Result<ArgumentsWithAliases>;
+
+      await eol.resolve(args);
+
+      expect(mockedPrompt).toBeCalledWith(
+        expect.objectContaining({
+          choices: ["Windows", "POSIX", "System default"]
+        })
+      );
+    });
+
+    it("should prompt the user with a message if an invalid line ending value is provided", async () => {
+      mockedPrompt.mockResolvedValue({
+        value: "dummy value"
+      });
+
+      const args = {
+        "--eol": "test"
+      } as Result<ArgumentsWithAliases>;
+
+      await eol.resolve(args);
+
+      expect(mockedPrompt).toBeCalledWith(
+        expect.objectContaining({
+          message: "Invalid line ending given. Please choose a line ending: "
+        })
+      );
+    });
+
+    [
+      { key: "Windows", value: "windows" },
+      { key: "POSIX", value: "posix" },
+      { key: "System default", value: undefined }
+    ].forEach(testCase =>
+      it(`should return ${testCase.value} if the user selects ${testCase.key} from the multiple choice prompt`, async () => {
+        mockedPrompt.mockResolvedValue({
+          value: testCase.key
+        });
+
+        const args = {
+          "--eol": testCase.key
+        } as Result<ArgumentsWithAliases>;
+
+        const answer = await eol.resolve(args);
+
+        expect(answer).toBe(testCase.value);
+      })
+    );
+  });
+
+  describe("parse", () => {
+    it("should return undefined if '--eol' is undefined", async () => {
+      const args = {} as Result<ArgumentsWithAliases>;
+
+      const answer = await eol.parse(args);
+
+      expect(answer).toBeUndefined();
+    });
+
+    it("should return 'windows' if '--eol' is 'windows'", async () => {
+      const args = {
+        "--eol": "windows"
+      } as Result<ArgumentsWithAliases>;
+
+      const answer = await eol.parse(args);
+
+      expect(answer).toBe("windows");
+    });
+
+    it("should return 'posix' if '--eol' is 'posix'", async () => {
+      const args = {
+        "--eol": "posix"
+      } as Result<ArgumentsWithAliases>;
+
+      const answer = await eol.parse(args);
+
+      expect(answer).toBe("posix");
+    });
+
+    it("should throw if '--eol' is invalid", async () => {
+      const args = {
+        "--eol": "this is invalid"
+      } as Result<ArgumentsWithAliases>;
+
+      await expect(eol.parse(args)).rejects.toThrow(
+        "Invalid line ending given: 'this is invalid'. Possible values are 'windows', 'posix'. Omit the --eol flag to use the system default."
+      );
+    });
+  });
 });

--- a/test/cli/args/input.spec.ts
+++ b/test/cli/args/input.spec.ts
@@ -39,155 +39,191 @@ describe("Input", () => {
     jest.restoreAllMocks();
   });
 
-  it("should return the inputted file name if the '--input' value is valid and exists", async () => {
-    mockedDoesFileExist.mockResolvedValue(true);
+  describe("resolve", () => {
+    it("should return the inputted file name if the '--input' value is valid and exists", async () => {
+      mockedDoesFileExist.mockResolvedValue(true);
 
-    const inputFile = "./package.json";
-    const args = {
-      "--input": inputFile
-    } as Result<ArgumentsWithAliases>;
+      const inputFile = "./package.json";
+      const args = {
+        "--input": inputFile
+      } as Result<ArgumentsWithAliases>;
 
-    const answer = await input.resolve(args);
+      const answer = await input.resolve(args);
 
-    expect(answer).toBe(inputFile);
-  });
-
-  it("should prompt for an input value if the '--input' value is undefined", async () => {
-    mockedDoesFileExist.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
-    mockedPrompt.mockResolvedValue({ value: "./package.json" });
-
-    const args = {} as Result<ArgumentsWithAliases>;
-
-    await input.resolve(args);
-
-    expect(mockedPrompt).toBeCalledTimes(1);
-  });
-
-  it("should prompt for an input value with a message if the '--input' value is undefined", async () => {
-    mockedDoesFileExist.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
-    mockedPrompt.mockResolvedValue({ value: "./package.json" });
-
-    const args = {} as Result<ArgumentsWithAliases>;
-
-    await input.resolve(args);
-
-    expect(mockedPrompt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "Package.json location: "
-      })
-    );
-  });
-
-  it("should prompt for an input value with an initial value of './package.json' if the input is undefined and a package.json was found", async () => {
-    mockedDoesFileExist.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
-    mockedPrompt.mockResolvedValue({ value: "./package.json" });
-
-    const args = {} as Result<ArgumentsWithAliases>;
-
-    await input.resolve(args);
-
-    expect(mockedPrompt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        initial: "./package.json"
-      })
-    );
-  });
-
-  it("should prompt for an input value with an empty initial value if the input is undefined and a package.json was not found", async () => {
-    mockedDoesFileExist.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
-    mockedPrompt.mockResolvedValue({ value: "./package.json" });
-
-    const args = {} as Result<ArgumentsWithAliases>;
-
-    await input.resolve(args);
-
-    expect(mockedPrompt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        initial: ""
-      })
-    );
-  });
-
-  it("should prompt for a string value if the '--input' value is undefined", async () => {
-    mockedDoesFileExist.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
-    mockedPrompt.mockResolvedValue({ value: "./package.json" });
-
-    const args = {} as Result<ArgumentsWithAliases>;
-
-    await input.resolve(args);
-
-    expect(mockedPrompt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "input"
-      })
-    );
-  });
-
-  it("should not fail the spinner if the '--input' value is undefined", async () => {
-    mockedDoesFileExist.mockImplementation((path: string) => {
-      return Promise.resolve(path === "./exists.json");
+      expect(answer).toBe(inputFile);
     });
 
-    mockedPrompt.mockResolvedValueOnce({ value: "./exists.json" });
+    it("should prompt for an input value if the '--input' value is undefined", async () => {
+      mockedDoesFileExist.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+      mockedPrompt.mockResolvedValue({ value: "./package.json" });
 
-    const args = {} as Result<ArgumentsWithAliases>;
+      const args = {} as Result<ArgumentsWithAliases>;
 
-    await input.resolve(args);
+      await input.resolve(args);
 
-    expect(mockedFailSpinner).toBeCalledTimes(0);
-  });
-
-  it("should fail the spinner if the initial input value doesn't exist", async () => {
-    mockedDoesFileExist.mockImplementation((path: string) => {
-      return Promise.resolve(path === "./exists.json");
+      expect(mockedPrompt).toBeCalledTimes(1);
     });
 
-    mockedPrompt.mockResolvedValueOnce({ value: "./exists.json" });
+    it("should prompt for an input value with a message if the '--input' value is undefined", async () => {
+      mockedDoesFileExist.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+      mockedPrompt.mockResolvedValue({ value: "./package.json" });
 
-    const args = {
-      "--input": "./not-exists.json"
-    } as Result<ArgumentsWithAliases>;
+      const args = {} as Result<ArgumentsWithAliases>;
 
-    await input.resolve(args);
+      await input.resolve(args);
 
-    expect(mockedFailSpinner).toBeCalledTimes(1);
-  });
-
-  it("should continue prompting for a value if the value doesn't exist", async () => {
-    mockedDoesFileExist.mockImplementation((path: string) => {
-      return Promise.resolve(path === "./exists.json");
+      expect(mockedPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Package.json location: "
+        })
+      );
     });
 
-    mockedPrompt
-      .mockResolvedValueOnce({ value: "./not-exists.json" })
-      .mockResolvedValueOnce({ value: "./not-exists.json" })
-      .mockResolvedValueOnce({ value: "./not-exists.json" })
-      .mockResolvedValueOnce({ value: "./exists.json" });
+    it("should prompt for an input value with an initial value of './package.json' if the input is undefined and a package.json was found", async () => {
+      mockedDoesFileExist.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+      mockedPrompt.mockResolvedValue({ value: "./package.json" });
 
-    const args = {} as Result<ArgumentsWithAliases>;
+      const args = {} as Result<ArgumentsWithAliases>;
 
-    await input.resolve(args);
+      await input.resolve(args);
 
-    expect(mockedPrompt).toBeCalledTimes(4);
-  });
-
-  it("should continue failing the spinner if the value doesn't exist", async () => {
-    mockedDoesFileExist.mockImplementation((path: string) => {
-      return Promise.resolve(path === "./exists.json");
+      expect(mockedPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initial: "./package.json"
+        })
+      );
     });
 
-    mockedPrompt
-      .mockResolvedValueOnce({ value: "./not-exists.json" })
-      .mockResolvedValueOnce({ value: "./not-exists.json" })
-      .mockResolvedValueOnce({ value: "./not-exists.json" })
-      .mockResolvedValueOnce({ value: "./exists.json" });
+    it("should prompt for an input value with an empty initial value if the input is undefined and a package.json was not found", async () => {
+      mockedDoesFileExist.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+      mockedPrompt.mockResolvedValue({ value: "./package.json" });
 
-    const args = {
-      "--input": "./not-exists.json"
-    } as Result<ArgumentsWithAliases>;
+      const args = {} as Result<ArgumentsWithAliases>;
 
-    await input.resolve(args);
+      await input.resolve(args);
 
-    expect(mockedFailSpinner).toBeCalledTimes(4);
+      expect(mockedPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initial: ""
+        })
+      );
+    });
+
+    it("should prompt for a string value if the '--input' value is undefined", async () => {
+      mockedDoesFileExist.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+      mockedPrompt.mockResolvedValue({ value: "./package.json" });
+
+      const args = {} as Result<ArgumentsWithAliases>;
+
+      await input.resolve(args);
+
+      expect(mockedPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "input"
+        })
+      );
+    });
+
+    it("should not fail the spinner if the '--input' value is undefined", async () => {
+      mockedDoesFileExist.mockImplementation((path: string) => {
+        return Promise.resolve(path === "./exists.json");
+      });
+
+      mockedPrompt.mockResolvedValueOnce({ value: "./exists.json" });
+
+      const args = {} as Result<ArgumentsWithAliases>;
+
+      await input.resolve(args);
+
+      expect(mockedFailSpinner).toBeCalledTimes(0);
+    });
+
+    it("should fail the spinner if the initial input value doesn't exist", async () => {
+      mockedDoesFileExist.mockImplementation((path: string) => {
+        return Promise.resolve(path === "./exists.json");
+      });
+
+      mockedPrompt.mockResolvedValueOnce({ value: "./exists.json" });
+
+      const args = {
+        "--input": "./not-exists.json"
+      } as Result<ArgumentsWithAliases>;
+
+      await input.resolve(args);
+
+      expect(mockedFailSpinner).toBeCalledTimes(1);
+    });
+
+    it("should continue prompting for a value if the value doesn't exist", async () => {
+      mockedDoesFileExist.mockImplementation((path: string) => {
+        return Promise.resolve(path === "./exists.json");
+      });
+
+      mockedPrompt
+        .mockResolvedValueOnce({ value: "./not-exists.json" })
+        .mockResolvedValueOnce({ value: "./not-exists.json" })
+        .mockResolvedValueOnce({ value: "./not-exists.json" })
+        .mockResolvedValueOnce({ value: "./exists.json" });
+
+      const args = {} as Result<ArgumentsWithAliases>;
+
+      await input.resolve(args);
+
+      expect(mockedPrompt).toBeCalledTimes(4);
+    });
+
+    it("should continue failing the spinner if the value doesn't exist", async () => {
+      mockedDoesFileExist.mockImplementation((path: string) => {
+        return Promise.resolve(path === "./exists.json");
+      });
+
+      mockedPrompt
+        .mockResolvedValueOnce({ value: "./not-exists.json" })
+        .mockResolvedValueOnce({ value: "./not-exists.json" })
+        .mockResolvedValueOnce({ value: "./not-exists.json" })
+        .mockResolvedValueOnce({ value: "./exists.json" });
+
+      const args = {
+        "--input": "./not-exists.json"
+      } as Result<ArgumentsWithAliases>;
+
+      await input.resolve(args);
+
+      expect(mockedFailSpinner).toBeCalledTimes(4);
+    });
+  });
+
+  describe("parse", () => {
+    it("should throw if the given input is undefined", async () => {
+      const args = {
+        "--input": undefined
+      } as Result<ArgumentsWithAliases>;
+
+      await expect(input.parse(args)).rejects.toThrow("No --input argument given.");
+    });
+
+    it("should throw if the given input does not exist", () => {
+      mockedDoesFileExist.mockResolvedValueOnce(false);
+
+      const args = {
+        "--input": "./package.json"
+      } as Result<ArgumentsWithAliases>;
+
+      return expect(input.parse(args)).rejects.toThrow(
+        "Given --input file not found. Cannot find './package.json'."
+      );
+    });
+
+    it("should return the given input if it exists", async () => {
+      mockedDoesFileExist.mockResolvedValueOnce(true);
+
+      const args = {
+        "--input": "./package.json"
+      } as Result<ArgumentsWithAliases>;
+
+      const result = await input.parse(args);
+
+      expect(result).toEqual("./package.json");
+    });
   });
 });

--- a/test/cli/args/no-spinner.spec.ts
+++ b/test/cli/args/no-spinner.spec.ts
@@ -31,4 +31,33 @@ describe("NoSpinner", () => {
       return expect(result).toBe(false);
     });
   });
+
+  describe("parse", () => {
+    [
+      { input: true, expected: true },
+      { input: false, expected: false },
+      { input: undefined, expected: false },
+      { input: null, expected: false }
+    ].forEach(({ input, expected }) =>
+      it(`should return ${expected} when the --no-spinner arg is ${input}`, async () => {
+        const noSpinner = new NoSpinner();
+
+        const args = {
+          "--no-spinner": input
+        } as Result<ArgumentsWithAliases>;
+
+        const result = await noSpinner.parse(args);
+        return expect(result).toBe(expected);
+      })
+    );
+
+    it(`should return false when the --no-spinner arg is not given`, async () => {
+      const noSpinner = new NoSpinner();
+
+      const args = {} as Result<ArgumentsWithAliases>;
+
+      const result = await noSpinner.parse(args);
+      return expect(result).toBe(false);
+    });
+  });
 });

--- a/test/cli/args/output.spec.ts
+++ b/test/cli/args/output.spec.ts
@@ -147,4 +147,51 @@ describe("Output", () => {
       expect(mockPrompt).not.toBeCalledWith(expect.objectContaining({ type: "confirm" }));
     });
   });
+
+  describe("parse", () => {
+    it("should throw if the given output is undefined", async () => {
+      const args = {
+        "--output": undefined
+      } as Result<ArgumentsWithAliases>;
+
+      await expect(output.parse(args)).rejects.toThrowError("No --output argument given.");
+    });
+
+    it("should throw if the given output file exists and overwrite is false", async () => {
+      mockDoesFileExist.mockResolvedValue(true);
+
+      const args = {
+        "--output": "any output value"
+      } as Result<ArgumentsWithAliases>;
+
+      await expect(output.parse(args)).rejects.toThrowError(
+        "Given --output file already exists at 'any output value'. Use --overwrite to allow overwriting."
+      );
+    });
+
+    it("should return the given output file if it exists but overwrite is true", async () => {
+      mockDoesFileExist.mockResolvedValue(true);
+
+      const args = {
+        "--output": "any output value",
+        "--overwrite": true
+      } as Result<ArgumentsWithAliases>;
+
+      const result = await output.parse(args);
+
+      expect(result).toEqual("any output value");
+    });
+
+    it("should return the given output file if it does not exist", async () => {
+      mockDoesFileExist.mockResolvedValue(false);
+
+      const args = {
+        "--output": "any output value"
+      } as Result<ArgumentsWithAliases>;
+
+      const result = await output.parse(args);
+
+      expect(result).toEqual("any output value");
+    });
+  });
 });

--- a/test/cli/index.spec.ts
+++ b/test/cli/index.spec.ts
@@ -19,32 +19,37 @@ jest.mock("../../src/cli/spinner", () => ({
   }
 }));
 
+const mockInputParse = jest.fn();
+const mockOutputParse = jest.fn();
+const mockEolParse = jest.fn();
+const mockNoSpinnerParse = jest.fn();
+
 const mockInputResolve = jest.fn();
 const mockOutputResolve = jest.fn();
 const mockEolResolve = jest.fn();
-const mockNoSpinner = jest.fn();
+const mockNoSpinnerResolve = jest.fn();
 
 jest.mock("../../src/cli/args/input.ts", () => ({
   Input: function () {
-    return { resolve: mockInputResolve };
+    return { parse: mockInputParse, resolve: mockInputResolve };
   }
 }));
 
 jest.mock("../../src/cli/args/output.ts", () => ({
   Output: function () {
-    return { resolve: mockOutputResolve };
+    return { parse: mockOutputParse, resolve: mockOutputResolve };
   }
 }));
 
 jest.mock("../../src/cli/args/eol.ts", () => ({
   Eol: function () {
-    return { resolve: mockEolResolve };
+    return { parse: mockEolParse, resolve: mockEolResolve };
   }
 }));
 
 jest.mock("../../src/cli/args/no-spinner.ts", () => ({
   NoSpinner: function () {
-    return { resolve: mockNoSpinner };
+    return { parse: mockNoSpinnerParse, resolve: mockNoSpinnerResolve };
   }
 }));
 
@@ -67,9 +72,7 @@ describe("cli", () => {
 
   describe("parseUserInputs", () => {
     it("should pass argumentsWithAliases to the arg library", async () => {
-      const args = ["", "", "--input", "any input path", "--output", "any output path"];
-
-      await main(args);
+      await main([]);
 
       const firstCallFirstArg = mockedArg.mock.calls[0][0];
       expect(firstCallFirstArg).toEqual(argumentsWithAliases);
@@ -88,40 +91,141 @@ describe("cli", () => {
     });
   });
 
-  describe("promptForMissingOptions", () => {
-    it("should give the parsed user args to the input resolver", async () => {
-      const allArgs = ["", "", "--input", "any input path", "--output", "any output path"];
+  describe("when --ci is false", () => {
+    let parsedArgResponse: Result<ArgumentsWithAliases>;
 
-      const parsedArgResponse = {
-        "--input": "any input path",
-        "--output": "any output path"
+    beforeEach(() => {
+      parsedArgResponse = {
+        "--ci": false
       } as Result<ArgumentsWithAliases>;
+    });
 
+    it("should give the parsed user args to the resolve method on the argument classes", async () => {
       mockedArg.mockReturnValue(parsedArgResponse);
 
-      await main(allArgs);
+      await main([]);
 
       expect(mockInputResolve).toHaveBeenCalledWith(parsedArgResponse);
-    });
-
-    it("should give the parsed user args to the output resolver", async () => {
-      const allArgs = ["", "", "--input", "any input path", "--output", "any output path"];
-
-      const parsedArgResponse = {
-        "--input": "any input path",
-        "--output": "any output path"
-      } as Result<ArgumentsWithAliases>;
-
-      mockedArg.mockReturnValue(parsedArgResponse);
-
-      await main(allArgs);
-
       expect(mockOutputResolve).toHaveBeenCalledWith(parsedArgResponse);
+      expect(mockEolResolve).toHaveBeenCalledWith(parsedArgResponse);
+      expect(mockNoSpinnerResolve).toHaveBeenCalledWith(parsedArgResponse);
     });
 
-    it("should give the parsed user args to the eol resolver", async () => {
-      const allArgs = ["", "", "--input", "any input path", "--output", "any output path"];
+    it("should call generateLicenseFile with the values from the resolve method on the argument classes", async () => {
+      mockedArg.mockReturnValue(parsedArgResponse);
 
+      mockInputResolve.mockResolvedValue("resolved input value");
+      mockOutputResolve.mockResolvedValue("resolved output value");
+      mockEolResolve.mockResolvedValue("resolved eol value");
+
+      await main([]);
+
+      const firstCallFirstArg = mockedGenerateLicenseFile.mock.calls[0][0];
+      expect(firstCallFirstArg).toBe("resolved input value");
+
+      const firstCallSecondArg = mockedGenerateLicenseFile.mock.calls[0][1];
+      expect(firstCallSecondArg).toBe("resolved output value");
+
+      const firstCallThirdArg = mockedGenerateLicenseFile.mock.calls[0][2];
+      expect(firstCallThirdArg).toBe("resolved eol value");
+    });
+  });
+
+  describe("when --ci is true", () => {
+    let parsedArgResponse: Result<ArgumentsWithAliases>;
+
+    beforeEach(() => {
+      parsedArgResponse = {
+        "--ci": true
+      } as Result<ArgumentsWithAliases>;
+    });
+
+    it("should set no-spinner to true", async () => {
+      const mockedArgs = {
+        "--ci": true,
+        "--no-spinner": undefined
+      } as Result<ArgumentsWithAliases>;
+      mockedArg.mockReturnValue(mockedArgs);
+
+      await main([]);
+
+      expect(mockedArgs["--no-spinner"]).toBe(true);
+    });
+
+    it("should give the parsed user args to the parse method on the argument classes", async () => {
+      mockedArg.mockReturnValue(parsedArgResponse);
+
+      await main([]);
+
+      expect(mockInputParse).toHaveBeenCalledWith(parsedArgResponse);
+      expect(mockOutputParse).toHaveBeenCalledWith(parsedArgResponse);
+      expect(mockEolParse).toHaveBeenCalledWith(parsedArgResponse);
+      expect(mockNoSpinnerParse).toHaveBeenCalledWith(parsedArgResponse);
+    });
+
+    it("should set an exit code of 1 when the parse method on an argument class throws an error", async () => {
+      const mockedArgs = {
+        "--ci": true
+      } as Result<ArgumentsWithAliases>;
+      mockedArg.mockReturnValue(mockedArgs);
+
+      mockInputParse.mockRejectedValueOnce("Some problem");
+
+      await main([]);
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("should call generateLicenseFile with the values from the parse methods on the argument classes", async () => {
+      mockedArg.mockReturnValue(parsedArgResponse);
+
+      mockInputParse.mockResolvedValue("resolved input value");
+      mockOutputParse.mockResolvedValue("resolved output value");
+      mockEolParse.mockResolvedValue("resolved eol value");
+
+      await main([]);
+
+      const firstCallFirstArg = mockedGenerateLicenseFile.mock.calls[0][0];
+      expect(firstCallFirstArg).toBe("resolved input value");
+
+      const firstCallSecondArg = mockedGenerateLicenseFile.mock.calls[0][1];
+      expect(firstCallSecondArg).toBe("resolved output value");
+
+      const firstCallThirdArg = mockedGenerateLicenseFile.mock.calls[0][2];
+      expect(firstCallThirdArg).toBe("resolved eol value");
+    });
+  });
+
+  describe("spinner", () => {
+    it("should start the spinner if noSpinner is false", async () => {
+      const parsedArgResponse = {
+        "--input": "any input path",
+        "--output": "any output path"
+      } as Result<ArgumentsWithAliases>;
+
+      mockedArg.mockReturnValue(parsedArgResponse);
+      mockNoSpinnerResolve.mockReturnValue(false);
+
+      await main([]);
+
+      expect(mockedStartSpinner).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not start the spinner if noSpinner is true", async () => {
+      const parsedArgResponse = {
+        "--input": "any input path",
+        "--output": "any output path"
+      } as Result<ArgumentsWithAliases>;
+
+      mockedArg.mockReturnValue(parsedArgResponse);
+      mockNoSpinnerResolve.mockReturnValue(true);
+
+      await main([]);
+
+      expect(mockedStartSpinner).toHaveBeenCalledTimes(0);
+    });
+
+    it("should stop the spinner if the generateLicenseFile call succeeds", async () => {
       const parsedArgResponse = {
         "--input": "any input path",
         "--output": "any output path"
@@ -129,106 +233,84 @@ describe("cli", () => {
 
       mockedArg.mockReturnValue(parsedArgResponse);
 
-      await main(allArgs);
+      await main([]);
 
-      expect(mockEolResolve).toHaveBeenCalledWith(parsedArgResponse);
+      expect(mockedStopSpinner).toHaveBeenCalledTimes(1);
     });
-  });
 
-  it("should start the spinner if noSpinner is false", async () => {
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
+    it("should not fail the spinner if the generateLicenseFile call succeeds", async () => {
+      const parsedArgResponse = {
+        "--input": "any input path",
+        "--output": "any output path"
+      } as Result<ArgumentsWithAliases>;
 
-    expect(mockedStartSpinner).toHaveBeenCalledTimes(1);
-  });
+      mockedArg.mockReturnValue(parsedArgResponse);
 
-  it("should not start the spinner if noSpinner is true", async () => {
-    mockNoSpinner.mockReturnValue(true);
+      await main([]);
 
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
+      expect(mockedFailSpinner).toHaveBeenCalledTimes(0);
+    });
 
-    expect(mockedStartSpinner).toHaveBeenCalledTimes(0);
-  });
+    it("should fail the spinner if the generateLicenseFile call throws", async () => {
+      mockedGenerateLicenseFile.mockReset();
+      mockedGenerateLicenseFile.mockRejectedValue(new Error("any error"));
 
-  it("should call generateLicenseFile with value from the input resolver", async () => {
-    mockInputResolve.mockResolvedValue("resolved input value");
+      await main([]);
 
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
+      expect(mockedFailSpinner).toHaveBeenCalledTimes(1);
+    });
 
-    const firstCallFirstArg = mockedGenerateLicenseFile.mock.calls[0][0];
-    expect(firstCallFirstArg).toBe("resolved input value");
-  });
+    it("should fail the spinner with the error message it an error is thrown", async () => {
+      const parsedArgResponse = {
+        "--input": "any input path",
+        "--output": "any output path"
+      } as Result<ArgumentsWithAliases>;
 
-  it("should call generateLicenseFile with value from the output resolver", async () => {
-    mockOutputResolve.mockResolvedValue("resolved output value");
+      mockedArg.mockReturnValue(parsedArgResponse);
+      mockedGenerateLicenseFile.mockReset();
+      mockedGenerateLicenseFile.mockRejectedValue(new Error("any error"));
 
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
+      await main([]);
 
-    const firstCallSecondArg = mockedGenerateLicenseFile.mock.calls[0][1];
-    expect(firstCallSecondArg).toBe("resolved output value");
-  });
+      expect(mockedFailSpinner).toHaveBeenCalledWith("any error");
+    });
 
-  it("should call generateLicenseFile with value from the eol resolver", async () => {
-    mockEolResolve.mockResolvedValue("resolved eol value");
+    it("should fail the spinner with the thrown object if it's not an error", async () => {
+      const parsedArgResponse = {
+        "--input": "any input path",
+        "--output": "any output path"
+      } as Result<ArgumentsWithAliases>;
 
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
+      mockedArg.mockReturnValue(parsedArgResponse);
+      mockedGenerateLicenseFile.mockReset();
+      mockedGenerateLicenseFile.mockRejectedValue("This string is not an error");
 
-    const firstCallThirdArg = mockedGenerateLicenseFile.mock.calls[0][2];
-    expect(firstCallThirdArg).toBe("resolved eol value");
-  });
+      await main([]);
 
-  it("should stop the spinner if the generateLicenseFile call succeeds", async () => {
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
+      expect(mockedFailSpinner).toHaveBeenCalledWith("This string is not an error");
+    });
 
-    expect(mockedStopSpinner).toHaveBeenCalledTimes(1);
-  });
+    it("should fail the spinner with 'Unknown error' if the value thrown is falsy (undefined)", async () => {
+      const parsedArgResponse = {
+        "--input": "any input path",
+        "--output": "any output path"
+      } as Result<ArgumentsWithAliases>;
 
-  it("should not fail the spinner if the generateLicenseFile call succeeds", async () => {
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
+      mockedArg.mockReturnValue(parsedArgResponse);
+      mockedGenerateLicenseFile.mockReset();
+      mockedGenerateLicenseFile.mockRejectedValue(undefined);
 
-    expect(mockedFailSpinner).toHaveBeenCalledTimes(0);
-  });
+      await main([]);
 
-  it("should fail the spinner if the generateLicenseFile call throws", async () => {
-    mockedGenerateLicenseFile.mockReset();
-    mockedGenerateLicenseFile.mockRejectedValue(new Error("any error"));
+      expect(mockedFailSpinner).toHaveBeenCalledWith("Unknown error");
+    });
 
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
+    it("should not stop the spinner if the generateLicenseFile call throws", async () => {
+      mockedGenerateLicenseFile.mockRejectedValue(new Error("any error"));
 
-    expect(mockedFailSpinner).toHaveBeenCalledTimes(1);
-  });
+      await main([]);
 
-  it("should fail the spinner with the error message it an error is thrown", async () => {
-    mockedGenerateLicenseFile.mockReset();
-    mockedGenerateLicenseFile.mockRejectedValue(new Error("any error"));
-
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
-
-    expect(mockedFailSpinner).toHaveBeenCalledWith("any error");
-  });
-
-  it("should fail the spinner with the thrown object if it's not an error", async () => {
-    mockedGenerateLicenseFile.mockReset();
-    mockedGenerateLicenseFile.mockRejectedValue("This string is not an error");
-
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
-
-    expect(mockedFailSpinner).toHaveBeenCalledWith("This string is not an error");
-  });
-
-  it("should fail the spinner with 'Unknown error' if the value thrown is falsy (undefined)", async () => {
-    mockedGenerateLicenseFile.mockReset();
-    mockedGenerateLicenseFile.mockRejectedValue(undefined);
-
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
-
-    expect(mockedFailSpinner).toHaveBeenCalledWith("Unknown error");
-  });
-
-  it("should not stop the spinner if the generateLicenseFile call throws", async () => {
-    mockedGenerateLicenseFile.mockRejectedValue(new Error("any error"));
-
-    await main(["", "", "--input", "any input path", "--output", "any output path"]);
-
-    expect(mockedStopSpinner).toHaveBeenCalledTimes(0);
+      expect(mockedStopSpinner).toHaveBeenCalledTimes(0);
+    });
   });
 });


### PR DESCRIPTION
Using the --ci flag stops the cli from prompting for options. This means that CI/CD environments can instantly fail rather than prompting and hanging.