### PR TITLE
Update output file name

### DIFF
--- a/src/cli/args/output.ts
+++ b/src/cli/args/output.ts
@@ -6,7 +6,7 @@ import { Argument } from "./argument";
 export class Output extends Argument<string> {
   private question = "Output location: ";
 
-  private initialValue = "3rd-party-licenses.txt";
+  private initialValue = "third-party-licenses.txt";
 
   public async resolve(args: Result<ArgumentsWithAliases>): Promise<string> {
     let output = args["--output"];


### PR DESCRIPTION
* Change output default file name from '3rd-party-licenses.txt' to 'third-party-licenses.txt'

Migration notes:
* Remove deprecated output file and regenerate with new filename. If you wish to keep the previous file name, please explicitly set the output filename by adding `--output 3rd-party-licenses.txt` to your command.