### PR TITLE
CI/CD adjustments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,6 @@ jobs:
       - name: Build docs site
         run: npm run build
         working-directory: ./website
+
+      - name: Check for git changes
+        run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,22 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: coverage
 
-      - name: Install website dependencies
+  website-ci:
+    runs-on: ubuntu-latest
+
+    name: Website CI
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node.JS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
         run: npm ci
         working-directory: ./website
 

--- a/.github/workflows/website-cd.yml
+++ b/.github/workflows/website-cd.yml
@@ -28,6 +28,9 @@ jobs:
         run: npm run build
         working-directory: ./website
 
+      - name: Check for git changes
+        run: git diff --exit-code
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
- Broken the website CI out into it's own job
  - It doesn't need to run on linux, mac, and windows across all nodejs versions because it's only ever built in CD where we control the OS and nodejs version
  - This should help to speed up CI runs

- Added a step to the website CI and CD processes to ensure they check for git diffs
  - This ensures that the committed version of the typedoc gen is always up to date on main