### PR TITLE
Fix the dependencies of publishable packages

### DIFF
--- a/.github/workflows/src-ci.yml
+++ b/.github/workflows/src-ci.yml
@@ -67,6 +67,10 @@ jobs:
         working-directory: ${{ env.CWD }}
         run: npm ci
 
+      - name: Build
+        working-directory: ${{ env.CWD }}
+        run: npx nx run-many --target build
+
       - name: Log Version
         shell: pwsh
         run: Write-Host ${{ inputs.version }}
@@ -75,10 +79,6 @@ jobs:
         if: inputs.version != ''
         working-directory: ${{ env.CWD }}
         run: npx nx run-many --target version --args="--version=${{ inputs.version }}"
-
-      - name: Build
-        working-directory: ${{ env.CWD }}
-        run: npx nx run-many --target build
 
       - name: Upload Build
         uses: actions/upload-artifact@v3

--- a/e2e/npm-package/test/cli/index.e2e.spec.ts
+++ b/e2e/npm-package/test/cli/index.e2e.spec.ts
@@ -169,17 +169,21 @@ describe("cli", () => {
       });
 
       it("should return the current version when --version is given", async () => {
+        const versionInPackageJson = "*";
+
         const { stdout } = await execAsync(
           `npx generate-license-file --version`
         );
 
-        expect(stdout.trim()).toBe("v0.0.0");
+        expect(stdout.trim()).toBe(`v${versionInPackageJson}`);
       });
 
       it("should return the current version when -v is given", async () => {
+        const versionInPackageJson = "*";
+
         const { stdout } = await execAsync(`npx generate-license-file -v`);
 
-        expect(stdout.trim()).toBe("v0.0.0");
+        expect(stdout.trim()).toBe(`v${versionInPackageJson}`);
       });
     });
   });

--- a/src/packages/generate-license-file-webpack-plugin/.eslintrc.json
+++ b/src/packages/generate-license-file-webpack-plugin/.eslintrc.json
@@ -3,6 +3,13 @@
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {
+      "files": ["{package,project}.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": "error"
+      }
+    },
+    {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {}
     },

--- a/src/packages/generate-license-file-webpack-plugin/package.json
+++ b/src/packages/generate-license-file-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-license-file-webpack-plugin",
-  "version": "0.0.0",
+  "version": "*",
   "main": "src/index.js",
   "license": "ISC",
   "description": "Webpack plugin to generate a text file asset containing all of the licenses for your production third-party dependencies.",
@@ -36,5 +36,10 @@
   },
   "files": [
     "src"
-  ]
+  ],
+  "dependencies": {
+    "webpack": "^5.75.0",
+    "tslib": "^2.3.0",
+    "generate-license-file": "*"
+  }
 }

--- a/src/packages/generate-license-file-webpack-plugin/project.json
+++ b/src/packages/generate-license-file-webpack-plugin/project.json
@@ -31,7 +31,11 @@
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/generate-license-file-webpack-plugin/**/*.ts"],
+        "lintFilePatterns": [
+          "packages/generate-license-file-webpack-plugin/**/*.ts",
+          "packages/generate-license-file-webpack-plugin/package.json",
+          "packages/generate-license-file-webpack-plugin/project.json"
+        ],
         "maxWarnings": 0
       }
     },

--- a/src/packages/generate-license-file/.eslintrc.json
+++ b/src/packages/generate-license-file/.eslintrc.json
@@ -3,6 +3,13 @@
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {
+      "files": ["{package,project}.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": "error"
+      }
+    },
+    {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {}
     },

--- a/src/packages/generate-license-file/package.json
+++ b/src/packages/generate-license-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-license-file",
-  "version": "0.0.0",
+  "version": "*",
   "description": "Generates a text file containing all of the licenses for your production dependencies",
   "main": "src/index.js",
   "license": "ISC",
@@ -40,5 +40,17 @@
   "homepage": "https://generate-license-file.js.org",
   "bin": {
     "generate-license-file": "bin/generate-license-file"
+  },
+  "dependencies": {
+    "@commander-js/extra-typings": "^11.0.0",
+    "@npmcli/arborist": "^7.0.0",
+    "cli-spinners": "^2.6.0",
+    "cosmiconfig": "^9.0.0",
+    "enquirer": "^2.3.6",
+    "glob": "^10.3.0",
+    "json5": "^2.2.3",
+    "ora": "^5.4.1",
+    "tslib": "^2.3.0",
+    "zod": "^3.21.4"
   }
 }

--- a/src/packages/generate-license-file/project.json
+++ b/src/packages/generate-license-file/project.json
@@ -40,7 +40,11 @@
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/generate-license-file/**/*.ts"],
+        "lintFilePatterns": [
+          "packages/generate-license-file/**/*.ts",
+          "packages/generate-license-file/package.json",
+          "packages/generate-license-file/project.json"
+        ],
         "maxWarnings": 0
       }
     },

--- a/src/tools/scripts/version.mjs
+++ b/src/tools/scripts/version.mjs
@@ -1,6 +1,7 @@
 import devkit from "@nx/devkit";
 import chalk from "chalk";
-import { execSync } from "child_process";
+import { join } from "path";
+import fs from "fs/promises";
 
 const { createProjectGraphAsync, readCachedProjectGraph } = devkit;
 
@@ -27,6 +28,11 @@ invariant(
   `Could not find project "${name}" in the workspace. Is the project.json configured correctly?`,
 );
 
-process.chdir(project.data.root);
+const distDir = project.data.targets.build.options.outputPath;
+const distPackageJson = join(distDir, "package.json");
 
-execSync("npm --no-git-tag-version --allow-same-version version " + version);
+await fs.access(distPackageJson);
+
+const packageJsonContent = await fs.readFile(distPackageJson, "utf8");
+const updatedPackageJsonContent = packageJsonContent.replace(/"\*"/g, `"${version}"`);
+await fs.writeFile(distPackageJson, updatedPackageJsonContent, "utf8");


### PR DESCRIPTION
In a recent nx version they removed the `updateBuildableProjectDepsInPackageJson` build flag and replaced it with an eslint rule.

While the migrations removed the old option from our project.json files, they did not enable the eslint rule.

This PR adds the eslint rule and also modifies the version.mjs script so that is can cover the gap between the old and the new solutions.

I suspect this will be a short-lived solution and we'll be able to use the `nx release` command once it's stable (currently in alpha).