### PR TITLE
Handle notice file content

### DIFF
--- a/e2e/.dependencies/dep-7/LICENSE.md
+++ b/e2e/.dependencies/dep-7/LICENSE.md
@@ -1,0 +1,3 @@
+# Dep Seven
+
+This license should be found.

--- a/e2e/.dependencies/dep-7/NOTICE
+++ b/e2e/.dependencies/dep-7/NOTICE
@@ -1,0 +1,1 @@
+This is the notice file bundled with dependency seven.

--- a/e2e/.dependencies/dep-7/README.md
+++ b/e2e/.dependencies/dep-7/README.md
@@ -1,0 +1,5 @@
+# Dep Six
+
+| Test Case | LICENSE.md | NOTICE.md |
+| --------- | ---------- | --------- |
+| Found     | TRUE       | TRUE      |

--- a/e2e/.dependencies/dep-7/README.md
+++ b/e2e/.dependencies/dep-7/README.md
@@ -1,4 +1,4 @@
-# Dep Six
+# Dep Seven
 
 | Test Case | LICENSE.md | NOTICE.md |
 | --------- | ---------- | --------- |

--- a/e2e/.dependencies/dep-7/package.json
+++ b/e2e/.dependencies/dep-7/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "dep-seven",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/e2e/config-file/test/cli/append/__snapshots__/append.e2e.spec.ts.snap
+++ b/e2e/config-file/test/cli/append/__snapshots__/append.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -21,7 +21,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -34,7 +34,7 @@ The following npm package may be included in this product:
 
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -48,7 +48,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -61,7 +61,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/e2e/config-file/test/cli/exclude/__snapshots__/exclude.e2e.spec.ts.snap
+++ b/e2e/config-file/test/cli/exclude/__snapshots__/exclude.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -21,7 +21,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -34,7 +34,7 @@ The following npm package may be included in this product:
 
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -48,7 +48,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 

--- a/e2e/config-file/test/cli/inputs-output/__snapshots__/inputs-output.e2e.spec.ts.snap
+++ b/e2e/config-file/test/cli/inputs-output/__snapshots__/inputs-output.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -21,7 +21,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -34,7 +34,7 @@ The following npm package may be included in this product:
 
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -48,7 +48,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -61,7 +61,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/e2e/config-file/test/cli/replacement/__snapshots__/replacement.e2e.spec.ts.snap
+++ b/e2e/config-file/test/cli/replacement/__snapshots__/replacement.e2e.spec.ts.snap
@@ -9,7 +9,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -22,7 +22,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Remote license
 
@@ -38,7 +38,7 @@ The following npm package may be included in this product:
 
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 I am the name-and-version replacement content.
 
@@ -48,7 +48,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 I am the name-only replacement content.
 
@@ -58,7 +58,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/e2e/multiple-inputs/test/cli/__snapshots__/index.e2e.spec.ts.snap
+++ b/e2e/multiple-inputs/test/cli/__snapshots__/index.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -22,7 +22,7 @@ The following npm packages may be included in this product:
  - dep-one@1.0.0
  - dep-six@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep One
 
@@ -33,9 +33,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -49,7 +65,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -62,7 +78,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/e2e/multiple-inputs/test/library/__snapshots__/generateLicenseFile.e2e.spec.ts.snap
+++ b/e2e/multiple-inputs/test/library/__snapshots__/generateLicenseFile.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -22,7 +22,7 @@ The following npm packages may be included in this product:
  - dep-one@1.0.0
  - dep-six@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep One
 
@@ -33,9 +33,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -49,7 +65,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -62,7 +78,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/e2e/multiple-inputs/test/library/__snapshots__/getLicenseFileText.e2e.spec.ts.snap
+++ b/e2e/multiple-inputs/test/library/__snapshots__/getLicenseFileText.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -22,7 +22,7 @@ The following npm packages may be included in this product:
  - dep-one@1.0.0
  - dep-six@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep One
 
@@ -33,9 +33,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -49,7 +65,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -62,7 +78,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/e2e/npm-package/package-lock.json
+++ b/e2e/npm-package/package-lock.json
@@ -11,6 +11,7 @@
         "dep-five": "file:../.dependencies/dep-5",
         "dep-four": "file:../.dependencies/dep-4",
         "dep-one": "file:../.dependencies/dep-1",
+        "dep-seven": "file:../.dependencies/dep-7",
         "dep-three": "file:../.dependencies/dep-3",
         "dep-two": "file:../.dependencies/dep-2",
         "dep-two-duplicate": "file:../.dependencies/dep-2-duplicate"
@@ -28,35 +29,23 @@
     "../../src/dist/packages/e2e-helpers": {
       "name": "@generate-license-file/e2e-helpers",
       "version": "0.0.1",
-      "dev": true,
-      "dependencies": {
-        "@commander-js/extra-typings": "^11.0.0",
-        "@npmcli/arborist": "^7.0.0",
-        "cli-spinners": "^2.6.0",
-        "cosmiconfig": "^8.2.0",
-        "enquirer": "^2.3.6",
-        "generate-license-file": "0.0.0",
-        "glob": "^10.3.0",
-        "json5": "^2.2.3",
-        "ora": "^5.4.1",
-        "tslib": "2.4.0",
-        "zod": "^3.21.4"
-      }
+      "dev": true
     },
     "../../src/dist/packages/generate-license-file": {
-      "version": "0.0.0",
+      "version": "*",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@commander-js/extra-typings": "^11.0.0",
+        "@commander-js/extra-typings": "^12.0.0",
         "@npmcli/arborist": "^7.0.0",
         "cli-spinners": "^2.6.0",
-        "cosmiconfig": "^8.2.0",
+        "commander": "^12.0.0",
+        "cosmiconfig": "^9.0.0",
         "enquirer": "^2.3.6",
         "glob": "^10.3.0",
         "json5": "^2.2.3",
         "ora": "^5.4.1",
-        "tslib": "2.4.0",
+        "tslib": "^2.3.0",
         "zod": "^3.21.4"
       },
       "bin": {
@@ -87,6 +76,10 @@
       "name": "dep-five",
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "../.dependencies/dep-7": {
+      "name": "dep-six",
+      "version": "1.0.0"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -1596,6 +1589,10 @@
     },
     "node_modules/dep-one": {
       "resolved": "../.dependencies/dep-1",
+      "link": true
+    },
+    "node_modules/dep-seven": {
+      "resolved": "../.dependencies/dep-7",
       "link": true
     },
     "node_modules/dep-three": {

--- a/e2e/npm-package/package.json
+++ b/e2e/npm-package/package.json
@@ -11,7 +11,8 @@
     "dep-one": "file:../.dependencies/dep-1",
     "dep-three": "file:../.dependencies/dep-3",
     "dep-two": "file:../.dependencies/dep-2",
-    "dep-two-duplicate": "file:../.dependencies/dep-2-duplicate"
+    "dep-two-duplicate": "file:../.dependencies/dep-2-duplicate",
+    "dep-seven": "file:../.dependencies/dep-7"
   },
   "devDependencies": {
     "@generate-license-file/e2e-helpers": "file:../../src/dist/packages/e2e-helpers",

--- a/e2e/npm-package/test/cli/__snapshots__/index.e2e.spec.ts.snap
+++ b/e2e/npm-package/test/cli/__snapshots__/index.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -21,7 +21,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -32,9 +32,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -48,7 +64,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -61,7 +77,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -80,7 +96,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -93,7 +109,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -104,9 +120,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -120,7 +152,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -133,7 +165,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -152,7 +184,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -165,7 +197,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -176,9 +208,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -192,7 +240,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -205,7 +253,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -224,7 +272,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -237,7 +285,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -248,9 +296,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -264,7 +328,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -277,7 +341,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -296,7 +360,7 @@ The following npm package may be included in this product:
 
  - dep-four
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -309,7 +373,7 @@ The following npm package may be included in this product:
 
  - dep-one
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -320,9 +384,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -336,7 +416,7 @@ The following npm packages may be included in this product:
  - dep-two
  - dep-two-duplicate
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -349,7 +429,7 @@ The following npm package may be included in this product:
 
  - dep-five
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -368,7 +448,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -381,7 +461,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -392,9 +472,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -408,7 +504,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -421,7 +517,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -440,7 +536,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -453,7 +549,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -464,9 +560,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -480,7 +592,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -493,7 +605,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -512,7 +624,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -525,7 +637,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -536,9 +648,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -552,7 +680,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -565,7 +693,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -584,7 +712,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -597,7 +725,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -608,9 +736,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -624,7 +768,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -637,7 +781,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -656,7 +800,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -669,7 +813,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -680,9 +824,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -696,7 +856,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -709,7 +869,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -728,7 +888,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -741,7 +901,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -752,9 +912,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -768,7 +944,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -781,7 +957,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -800,7 +976,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -813,7 +989,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -824,9 +1000,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -840,7 +1032,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -853,7 +1045,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -872,7 +1064,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -885,7 +1077,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -896,9 +1088,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -912,7 +1120,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -925,7 +1133,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -944,7 +1152,7 @@ The following npm package may be included in this product:
 
  - dep-four
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -957,7 +1165,7 @@ The following npm package may be included in this product:
 
  - dep-one
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -968,9 +1176,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -984,7 +1208,7 @@ The following npm packages may be included in this product:
  - dep-two
  - dep-two-duplicate
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -997,7 +1221,7 @@ The following npm package may be included in this product:
 
  - dep-five
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -1016,7 +1240,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -1029,7 +1253,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -1040,9 +1264,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -1056,7 +1296,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -1069,7 +1309,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -1088,7 +1328,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -1101,7 +1341,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -1112,9 +1352,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -1128,7 +1384,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -1141,7 +1397,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -1160,7 +1416,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -1173,7 +1429,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -1184,9 +1440,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -1200,7 +1472,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -1213,7 +1485,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -1232,7 +1504,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -1245,7 +1517,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -1256,9 +1528,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -1272,7 +1560,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -1285,7 +1573,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/e2e/npm-package/test/library/__snapshots__/generateLicenseFile.e2e.spec.ts.snap
+++ b/e2e/npm-package/test/library/__snapshots__/generateLicenseFile.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -21,7 +21,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -32,9 +32,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -48,7 +64,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -61,7 +77,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -80,7 +96,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -93,7 +109,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -104,9 +120,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -120,7 +152,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -133,7 +165,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -152,7 +184,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -165,7 +197,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -176,9 +208,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -192,7 +240,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -205,7 +253,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -224,7 +272,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -237,7 +285,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -248,9 +296,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -264,7 +328,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -277,7 +341,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -296,7 +360,7 @@ The following npm package may be included in this product:
 
  - dep-four
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -309,7 +373,7 @@ The following npm package may be included in this product:
 
  - dep-one
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -320,9 +384,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -336,7 +416,7 @@ The following npm packages may be included in this product:
  - dep-two
  - dep-two-duplicate
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -349,7 +429,7 @@ The following npm package may be included in this product:
 
  - dep-five
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/e2e/npm-package/test/library/__snapshots__/getLicenseFileText.e2e.spec.ts.snap
+++ b/e2e/npm-package/test/library/__snapshots__/getLicenseFileText.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -21,7 +21,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -32,9 +32,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -48,7 +64,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -61,7 +77,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -80,7 +96,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -93,7 +109,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -104,9 +120,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -120,7 +152,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -133,7 +165,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -152,7 +184,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -165,7 +197,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -176,9 +208,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -192,7 +240,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -205,7 +253,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -224,7 +272,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -237,7 +285,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -248,9 +296,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven@1.0.0
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -264,7 +328,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -277,7 +341,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 
@@ -296,7 +360,7 @@ The following npm package may be included in this product:
 
  - dep-four
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -309,7 +373,7 @@ The following npm package may be included in this product:
 
  - dep-one
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -320,9 +384,25 @@ This license should be found.
 
 The following npm package may be included in this product:
 
+ - dep-seven
+
+This package contains the following license:
+
+# Dep Seven
+
+This license should be found.
+
+With the following notices:
+
+This is the notice file bundled with dependency seven.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-three
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -336,7 +416,7 @@ The following npm packages may be included in this product:
  - dep-two
  - dep-two-duplicate
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -349,7 +429,7 @@ The following npm package may be included in this product:
 
  - dep-five
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/e2e/npm-package/test/library/__snapshots__/getProjectLicenses.e2e.spec.ts.snap
+++ b/e2e/npm-package/test/library/__snapshots__/getProjectLicenses.e2e.spec.ts.snap
@@ -7,6 +7,7 @@ exports[`getProjectLicenses for a relative path should match snapshot 1`] = `
     "dependencies": [
       "dep-five@1.0.0",
     ],
+    "notices": null,
   },
   {
     "content": "# Dep Four
@@ -16,6 +17,7 @@ This license should be found.",
     "dependencies": [
       "dep-four@1.0.0",
     ],
+    "notices": null,
   },
   {
     "content": "# Dep One
@@ -26,6 +28,18 @@ This license should be found.
     "dependencies": [
       "dep-one@1.0.0",
     ],
+    "notices": null,
+  },
+  {
+    "content": "# Dep Seven
+
+This license should be found.
+",
+    "dependencies": [
+      "dep-seven@1.0.0",
+    ],
+    "notices": "This is the notice file bundled with dependency seven.
+",
   },
   {
     "content": "# Dep Three
@@ -35,6 +49,7 @@ This license should be found.",
     "dependencies": [
       "dep-three@1.0.0",
     ],
+    "notices": null,
   },
   {
     "content": "# Dep Two
@@ -46,6 +61,7 @@ This license should be found.
       "dep-two@1.0.0",
       "dep-two-duplicate@1.0.0",
     ],
+    "notices": null,
   },
 ]
 `;
@@ -57,6 +73,7 @@ exports[`getProjectLicenses for an absolute path should match snapshot 1`] = `
     "dependencies": [
       "dep-five@1.0.0",
     ],
+    "notices": null,
   },
   {
     "content": "# Dep Four
@@ -66,6 +83,7 @@ This license should be found.",
     "dependencies": [
       "dep-four@1.0.0",
     ],
+    "notices": null,
   },
   {
     "content": "# Dep One
@@ -76,6 +94,18 @@ This license should be found.
     "dependencies": [
       "dep-one@1.0.0",
     ],
+    "notices": null,
+  },
+  {
+    "content": "# Dep Seven
+
+This license should be found.
+",
+    "dependencies": [
+      "dep-seven@1.0.0",
+    ],
+    "notices": "This is the notice file bundled with dependency seven.
+",
   },
   {
     "content": "# Dep Three
@@ -85,6 +115,7 @@ This license should be found.",
     "dependencies": [
       "dep-three@1.0.0",
     ],
+    "notices": null,
   },
   {
     "content": "# Dep Two
@@ -96,6 +127,7 @@ This license should be found.
       "dep-two@1.0.0",
       "dep-two-duplicate@1.0.0",
     ],
+    "notices": null,
   },
 ]
 `;
@@ -107,6 +139,7 @@ exports[`getProjectLicenses should not include versions when omitVersions is tru
     "dependencies": [
       "dep-five",
     ],
+    "notices": null,
   },
   {
     "content": "# Dep Four
@@ -116,6 +149,7 @@ This license should be found.",
     "dependencies": [
       "dep-four",
     ],
+    "notices": null,
   },
   {
     "content": "# Dep One
@@ -126,6 +160,18 @@ This license should be found.
     "dependencies": [
       "dep-one",
     ],
+    "notices": null,
+  },
+  {
+    "content": "# Dep Seven
+
+This license should be found.
+",
+    "dependencies": [
+      "dep-seven",
+    ],
+    "notices": "This is the notice file bundled with dependency seven.
+",
   },
   {
     "content": "# Dep Three
@@ -135,6 +181,7 @@ This license should be found.",
     "dependencies": [
       "dep-three",
     ],
+    "notices": null,
   },
   {
     "content": "# Dep Two
@@ -146,6 +193,7 @@ This license should be found.
       "dep-two",
       "dep-two-duplicate",
     ],
+    "notices": null,
   },
 ]
 `;

--- a/e2e/npm-package/test/library/__snapshots__/getProjectLicenses.e2e.spec.ts.snap
+++ b/e2e/npm-package/test/library/__snapshots__/getProjectLicenses.e2e.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`getProjectLicenses for a relative path should match snapshot 1`] = `
     "dependencies": [
       "dep-five@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep Four
@@ -17,7 +17,7 @@ This license should be found.",
     "dependencies": [
       "dep-four@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep One
@@ -28,7 +28,7 @@ This license should be found.
     "dependencies": [
       "dep-one@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep Seven
@@ -38,8 +38,10 @@ This license should be found.
     "dependencies": [
       "dep-seven@1.0.0",
     ],
-    "notices": "This is the notice file bundled with dependency seven.
+    "notices": [
+      "This is the notice file bundled with dependency seven.
 ",
+    ],
   },
   {
     "content": "# Dep Three
@@ -49,7 +51,7 @@ This license should be found.",
     "dependencies": [
       "dep-three@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep Two
@@ -61,7 +63,7 @@ This license should be found.
       "dep-two@1.0.0",
       "dep-two-duplicate@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
 ]
 `;
@@ -73,7 +75,7 @@ exports[`getProjectLicenses for an absolute path should match snapshot 1`] = `
     "dependencies": [
       "dep-five@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep Four
@@ -83,7 +85,7 @@ This license should be found.",
     "dependencies": [
       "dep-four@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep One
@@ -94,7 +96,7 @@ This license should be found.
     "dependencies": [
       "dep-one@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep Seven
@@ -104,8 +106,10 @@ This license should be found.
     "dependencies": [
       "dep-seven@1.0.0",
     ],
-    "notices": "This is the notice file bundled with dependency seven.
+    "notices": [
+      "This is the notice file bundled with dependency seven.
 ",
+    ],
   },
   {
     "content": "# Dep Three
@@ -115,7 +119,7 @@ This license should be found.",
     "dependencies": [
       "dep-three@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep Two
@@ -127,7 +131,7 @@ This license should be found.
       "dep-two@1.0.0",
       "dep-two-duplicate@1.0.0",
     ],
-    "notices": null,
+    "notices": [],
   },
 ]
 `;
@@ -139,7 +143,7 @@ exports[`getProjectLicenses should not include versions when omitVersions is tru
     "dependencies": [
       "dep-five",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep Four
@@ -149,7 +153,7 @@ This license should be found.",
     "dependencies": [
       "dep-four",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep One
@@ -160,7 +164,7 @@ This license should be found.
     "dependencies": [
       "dep-one",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep Seven
@@ -170,8 +174,10 @@ This license should be found.
     "dependencies": [
       "dep-seven",
     ],
-    "notices": "This is the notice file bundled with dependency seven.
+    "notices": [
+      "This is the notice file bundled with dependency seven.
 ",
+    ],
   },
   {
     "content": "# Dep Three
@@ -181,7 +187,7 @@ This license should be found.",
     "dependencies": [
       "dep-three",
     ],
-    "notices": null,
+    "notices": [],
   },
   {
     "content": "# Dep Two
@@ -193,7 +199,7 @@ This license should be found.
       "dep-two",
       "dep-two-duplicate",
     ],
-    "notices": null,
+    "notices": [],
   },
 ]
 `;

--- a/e2e/pnpm/test/__snapshots__/index.e2e.spec.ts.snap
+++ b/e2e/pnpm/test/__snapshots__/index.e2e.spec.ts.snap
@@ -8,7 +8,7 @@ The following npm package may be included in this product:
 
  - dep-four@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Four
 
@@ -21,7 +21,7 @@ The following npm package may be included in this product:
 
  - dep-one@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep One
 
@@ -34,7 +34,7 @@ The following npm package may be included in this product:
 
  - dep-three@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 # Dep Three
 
@@ -48,7 +48,7 @@ The following npm packages may be included in this product:
  - dep-two-duplicate@1.0.0
  - dep-two@1.0.0
 
-These packages each contain the following license and notice below:
+These packages each contain the following license:
 
 # Dep Two
 
@@ -61,7 +61,7 @@ The following npm package may be included in this product:
 
  - dep-five@1.0.0
 
-This package contains the following license and notice below:
+This package contains the following license:
 
 MIT
 

--- a/src/packages/generate-license-file/src/lib/getLicenseFileText.ts
+++ b/src/packages/generate-license-file/src/lib/getLicenseFileText.ts
@@ -68,7 +68,7 @@ export async function getLicenseFileText(
 
     const license = new License(
       resolvedLicense.licenseContent,
-      resolvedLicense.noticeContent,
+      resolvedLicense.notices,
       dependencies,
     );
     licenseFile += license.format(EOL) + EOL + EOL + SUFFIX + EOL + EOL;

--- a/src/packages/generate-license-file/src/lib/getLicenseFileText.ts
+++ b/src/packages/generate-license-file/src/lib/getLicenseFileText.ts
@@ -66,7 +66,11 @@ export async function getLicenseFileText(
       return `${dep.name}@${dep.version ?? "unknown"}`;
     });
 
-    const license = new License(resolvedLicense.licenseContent, dependencies);
+    const license = new License(
+      resolvedLicense.licenseContent,
+      resolvedLicense.noticeContent,
+      dependencies,
+    );
     licenseFile += license.format(EOL) + EOL + EOL + SUFFIX + EOL + EOL;
   }
 

--- a/src/packages/generate-license-file/src/lib/getProjectLicenses.ts
+++ b/src/packages/generate-license-file/src/lib/getProjectLicenses.ts
@@ -35,6 +35,7 @@ export async function getProjectLicenses(
 
     results.push({
       content: license.licenseContent,
+      notices: license.noticeContent,
       dependencies,
     });
   }

--- a/src/packages/generate-license-file/src/lib/getProjectLicenses.ts
+++ b/src/packages/generate-license-file/src/lib/getProjectLicenses.ts
@@ -35,7 +35,7 @@ export async function getProjectLicenses(
 
     results.push({
       content: license.licenseContent,
-      notices: license.noticeContent,
+      notices: license.notices,
       dependencies,
     });
   }

--- a/src/packages/generate-license-file/src/lib/internal/resolveDependencies/index.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveDependencies/index.ts
@@ -1,6 +1,6 @@
 ﻿import { dirname, join } from "path";
 import { doesFileExist } from "../../utils/file.utils";
-import { LicenseNoticePair, ResolvedLicense } from "../resolveLicenses";
+import { LicenseNoticeKey, ResolvedLicense } from "../resolveLicenses";
 import { resolveDependenciesForNpmProject } from "./resolveNpmDependencies";
 import { resolveDependenciesForPnpmProject } from "./resolvePnpmDependencies";
 
@@ -13,7 +13,7 @@ type PackageManager = "npm" | "pnpm";
 
 export const resolveDependencies = async (
   packageJson: string,
-  licensesMap: Map<LicenseNoticePair, ResolvedLicense>,
+  licensesMap: Map<LicenseNoticeKey, ResolvedLicense>,
   options?: ResolveLicensesOptions,
 ) => {
   const packageManager = await resolvePackageManager(packageJson);

--- a/src/packages/generate-license-file/src/lib/internal/resolveDependencies/index.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveDependencies/index.ts
@@ -1,6 +1,6 @@
 ﻿import { dirname, join } from "path";
 import { doesFileExist } from "../../utils/file.utils";
-import { Dependency, LicenseContent } from "../resolveLicenses";
+import { LicenseNoticePair, ResolvedLicense } from "../resolveLicenses";
 import { resolveDependenciesForNpmProject } from "./resolveNpmDependencies";
 import { resolveDependenciesForPnpmProject } from "./resolvePnpmDependencies";
 
@@ -13,7 +13,7 @@ type PackageManager = "npm" | "pnpm";
 
 export const resolveDependencies = async (
   packageJson: string,
-  licensesMap: Map<LicenseContent, Dependency[]>,
+  licensesMap: Map<LicenseNoticePair, ResolvedLicense>,
   options?: ResolveLicensesOptions,
 ) => {
   const packageManager = await resolvePackageManager(packageJson);

--- a/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolveNpmDependencies.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolveNpmDependencies.ts
@@ -3,7 +3,8 @@ import { dirname, isAbsolute, join } from "path";
 import logger from "../../utils/console.utils";
 import { readPackageJson } from "../../utils/packageJson.utils";
 import { resolveLicenseContent } from "../resolveLicenseContent";
-import { Dependency, LicenseContent } from "../resolveLicenses";
+import { LicenseNoticePair, ResolvedLicense } from "../resolveLicenses";
+import { resolveNoticeContent } from "../resolveNoticeContent";
 
 type ResolveLicensesOptions = {
   replace?: Record<string, string>;
@@ -12,7 +13,7 @@ type ResolveLicensesOptions = {
 
 export const resolveDependenciesForNpmProject = async (
   packageJson: string,
-  licensesMap: Map<LicenseContent, Dependency[]>,
+  licensesMap: Map<LicenseNoticePair, ResolvedLicense>,
   options?: ResolveLicensesOptions,
 ) => {
   const replacements = options?.replace ?? {};
@@ -39,18 +40,28 @@ export const resolveDependenciesForNpmProject = async (
 
     try {
       const licenseContent = await resolveLicenseContent(node.realpath, packageJson, replacements);
+      const noticeContent = await resolveNoticeContent(node.realpath);
 
-      const dependencies = licensesMap.get(licenseContent) ?? [];
+      const licenseNoticePair: LicenseNoticePair = `${licenseContent}:${noticeContent ?? ""}`;
 
-      const alreadyExists = dependencies.find(
+      const resolvedLicense: ResolvedLicense = licensesMap.get(licenseNoticePair) ?? {
+        dependencies: [],
+        licenseContent,
+        noticeContent,
+      };
+
+      const alreadyExists = resolvedLicense.dependencies.find(
         dep => dep.name === node.package.name && dep.version === node.package.version,
       );
 
       if (!alreadyExists) {
-        dependencies.push({ name: node.package.name ?? node.name, version: node.package.version });
+        resolvedLicense.dependencies.push({
+          name: node.package.name ?? node.name,
+          version: node.package.version,
+        });
       }
 
-      licensesMap.set(licenseContent, dependencies);
+      licensesMap.set(licenseNoticePair, resolvedLicense);
     } catch (error) {
       const warningLines = [
         `Unable to determine license content for ${packageJson.name}@${packageJson.version} with error:`,

--- a/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolveNpmDependencies.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolveNpmDependencies.ts
@@ -40,7 +40,7 @@ export const resolveDependenciesForNpmProject = async (
 
     try {
       const licenseContent = await resolveLicenseContent(node.realpath, packageJson, replacements);
-      const noticeContent = await resolveNoticeContent(node.realpath);
+      const noticeContent = await resolveNoticeContent({ directory: node.realpath, packageJson });
 
       const licenseNoticePair: LicenseNoticePair = `${licenseContent}:${noticeContent ?? ""}`;
 

--- a/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolvePnpmDependencies.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolvePnpmDependencies.ts
@@ -3,7 +3,8 @@ import logger from "../../utils/console.utils";
 import { readPackageJson } from "../../utils/packageJson.utils";
 import { getPnpmProjectDependencies, getPnpmVersion } from "../../utils/pnpmCli.utils";
 import { resolveLicenseContent } from "../resolveLicenseContent";
-import { Dependency, LicenseContent } from "../resolveLicenses";
+import { LicenseNoticePair, ResolvedLicense } from "../resolveLicenses";
+import { resolveNoticeContent } from "../resolveNoticeContent";
 
 type ResolveLicensesOptions = {
   replace?: Record<string, string>;
@@ -13,7 +14,7 @@ type ResolveLicensesOptions = {
 
 export const resolveDependenciesForPnpmProject = async (
   packageJson: string,
-  licensesMap: Map<LicenseContent, Dependency[]>,
+  licensesMap: Map<LicenseNoticePair, ResolvedLicense>,
   options?: ResolveLicensesOptions,
 ) => {
   const replacements = options?.replace ?? {};
@@ -41,18 +42,28 @@ export const resolveDependenciesForPnpmProject = async (
           packageJson,
           replacements,
         );
+        const noticeContent = await resolveNoticeContent(dependencyPath);
 
-        const dependencies = licensesMap.get(licenseContent) ?? [];
+        const licenseNoticePair: LicenseNoticePair = `${licenseContent}:${noticeContent ?? ""}`;
 
-        const alreadyExists = dependencies.find(
+        const resolvedLicense: ResolvedLicense = licensesMap.get(licenseNoticePair) ?? {
+          dependencies: [],
+          licenseContent,
+          noticeContent,
+        };
+
+        const alreadyExists = resolvedLicense.dependencies.find(
           dep => dep.name === dependency.name && dep.version === packageJson.version,
         );
 
         if (!alreadyExists) {
-          dependencies.push({ name: dependency.name, version: packageJson.version });
+          resolvedLicense.dependencies.push({
+            name: dependency.name,
+            version: packageJson.version,
+          });
         }
 
-        licensesMap.set(licenseContent, dependencies);
+        licensesMap.set(licenseNoticePair, resolvedLicense);
       } catch (error) {
         const warningLines = [
           `Unable to determine license content for ${packageJson.name}@${packageJson.version} with error:`,

--- a/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolvePnpmDependencies.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolvePnpmDependencies.ts
@@ -42,7 +42,10 @@ export const resolveDependenciesForPnpmProject = async (
           packageJson,
           replacements,
         );
-        const noticeContent = await resolveNoticeContent(dependencyPath);
+        const noticeContent = await resolveNoticeContent({
+          directory: dependencyPath,
+          packageJson,
+        });
 
         const licenseNoticePair: LicenseNoticePair = `${licenseContent}:${noticeContent ?? ""}`;
 

--- a/src/packages/generate-license-file/src/lib/internal/resolveLicenseContent/licenseFile.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveLicenseContent/licenseFile.ts
@@ -15,7 +15,7 @@ export const extensionDenyList = [".js", ".ts", ".sh", ".ps1"];
 export const licenseFile: Resolution = async inputs => {
   const { directory, packageJson } = inputs;
 
-  const licenseFiles = await glob("{license,licence,copying,notice}{,-*,.*}", {
+  const licenseFiles = await glob("{license,licence,copying}{,-*,.*}", {
     nocase: true,
     nodir: true,
     absolute: true,

--- a/src/packages/generate-license-file/src/lib/internal/resolveLicenses.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveLicenses.ts
@@ -6,6 +6,8 @@ type ResolveLicensesOptions = {
 };
 
 export type LicenseContent = string;
+export type NoticeContent = string;
+export type LicenseNoticePair = `${LicenseContent}:${NoticeContent}`;
 
 export type Dependency = {
   name: string;
@@ -14,6 +16,7 @@ export type Dependency = {
 
 export type ResolvedLicense = {
   licenseContent: LicenseContent;
+  noticeContent: NoticeContent | null;
   dependencies: Dependency[];
 };
 
@@ -21,23 +24,11 @@ export const resolveLicenses = async (
   packageJsons: string[],
   options?: ResolveLicensesOptions,
 ): Promise<ResolvedLicense[]> => {
-  const licensesMap = new Map<LicenseContent, Dependency[]>();
+  const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
 
   for (const packageJson of packageJsons) {
     await resolveDependencies(packageJson, licensesMap, options);
   }
 
-  return flattenDependencyMapToLicenseArray(licensesMap);
-};
-
-const flattenDependencyMapToLicenseArray = (
-  dependencyLicenses: Map<LicenseContent, Dependency[]>,
-): ResolvedLicense[] => {
-  const licenses: ResolvedLicense[] = [];
-
-  for (const [licenseContent, dependencies] of dependencyLicenses) {
-    licenses.push({ licenseContent, dependencies });
-  }
-
-  return licenses;
+  return Array.from(licensesMap.values());
 };

--- a/src/packages/generate-license-file/src/lib/internal/resolveLicenses.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveLicenses.ts
@@ -6,8 +6,8 @@ type ResolveLicensesOptions = {
 };
 
 export type LicenseContent = string;
-export type NoticeContent = string;
-export type LicenseNoticePair = `${LicenseContent}:${NoticeContent}`;
+export type NoticeKey = string;
+export type LicenseNoticeKey = `${LicenseContent}:${NoticeKey}`;
 
 export type Dependency = {
   name: string;
@@ -16,7 +16,7 @@ export type Dependency = {
 
 export type ResolvedLicense = {
   licenseContent: LicenseContent;
-  noticeContent: NoticeContent | null;
+  notices: string[];
   dependencies: Dependency[];
 };
 
@@ -24,7 +24,7 @@ export const resolveLicenses = async (
   packageJsons: string[],
   options?: ResolveLicensesOptions,
 ): Promise<ResolvedLicense[]> => {
-  const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
+  const licensesMap = new Map<LicenseNoticeKey, ResolvedLicense>();
 
   for (const packageJson of packageJsons) {
     await resolveDependencies(packageJson, licensesMap, options);

--- a/src/packages/generate-license-file/src/lib/internal/resolveNoticeContent/index.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveNoticeContent/index.ts
@@ -1,0 +1,20 @@
+import { glob } from "glob";
+import { readFile } from "../../utils/file.utils";
+
+type ResolvedNotice = string | null;
+
+export const resolveNoticeContent = async (directory: string): Promise<ResolvedNotice> => {
+  const noticeFiles = await glob("notice{,-*,.*}", {
+    nocase: true,
+    nodir: true,
+    absolute: true,
+    cwd: directory,
+    maxDepth: 1,
+  });
+
+  if (noticeFiles.length === 0) {
+    return null;
+  }
+
+  return await readFile(noticeFiles[0], { encoding: "utf-8" });
+};

--- a/src/packages/generate-license-file/src/lib/internal/resolveNoticeContent/index.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveNoticeContent/index.ts
@@ -1,13 +1,7 @@
 import { glob } from "glob";
-import { relative } from "path";
-import logger from "../../utils/console.utils";
 import { readFile } from "../../utils/file.utils";
-import { ResolutionInputs } from "../resolveLicenseContent";
 
-type ResolvedNotice = string | null;
-
-export const resolveNoticeContent = async (inputs: ResolutionInputs): Promise<ResolvedNotice> => {
-  const { directory, packageJson } = inputs;
+export const resolveNotices = async (directory: string): Promise<string[]> => {
   const noticeFiles = await glob("notice{,-*,.*}", {
     nocase: true,
     nodir: true,
@@ -17,22 +11,12 @@ export const resolveNoticeContent = async (inputs: ResolutionInputs): Promise<Re
   });
 
   if (noticeFiles.length === 0) {
-    return null;
+    return [];
   }
 
-  if (noticeFiles.length > 1) {
-    const relativeNoticeFiles = noticeFiles.map(file => ` - ./${relative(directory, file)}`);
+  const contents = await Promise.all(
+    noticeFiles.map(async f => await readFile(f, { encoding: "utf-8" })),
+  );
 
-    const warningLines = [
-      `Found multiple notice files for ${packageJson.name}@${packageJson.version}:`,
-      ...relativeNoticeFiles,
-      "We suggest you determine which file(s) you wish to include and use a config file to configure the output for this package.",
-      "See: https://generate-license-file.js.org/docs/cli/config-file for more information.",
-      "", // Empty line for spacing
-    ];
-
-    logger.warn(warningLines.join("\n"));
-  }
-
-  return await readFile(noticeFiles[0], { encoding: "utf-8" });
+  return contents;
 };

--- a/src/packages/generate-license-file/src/lib/internal/resolveNoticeContent/index.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveNoticeContent/index.ts
@@ -1,9 +1,13 @@
 import { glob } from "glob";
+import { relative } from "path";
+import logger from "../../utils/console.utils";
 import { readFile } from "../../utils/file.utils";
+import { ResolutionInputs } from "../resolveLicenseContent";
 
 type ResolvedNotice = string | null;
 
-export const resolveNoticeContent = async (directory: string): Promise<ResolvedNotice> => {
+export const resolveNoticeContent = async (inputs: ResolutionInputs): Promise<ResolvedNotice> => {
+  const { directory, packageJson } = inputs;
   const noticeFiles = await glob("notice{,-*,.*}", {
     nocase: true,
     nodir: true,
@@ -14,6 +18,20 @@ export const resolveNoticeContent = async (directory: string): Promise<ResolvedN
 
   if (noticeFiles.length === 0) {
     return null;
+  }
+
+  if (noticeFiles.length > 1) {
+    const relativeNoticeFiles = noticeFiles.map(file => ` - ./${relative(directory, file)}`);
+
+    const warningLines = [
+      `Found multiple notice files for ${packageJson.name}@${packageJson.version}:`,
+      ...relativeNoticeFiles,
+      "We suggest you determine which file(s) you wish to include and use a config file to configure the output for this package.",
+      "See: https://generate-license-file.js.org/docs/cli/config-file for more information.",
+      "", // Empty line for spacing
+    ];
+
+    logger.warn(warningLines.join("\n"));
   }
 
   return await readFile(noticeFiles[0], { encoding: "utf-8" });

--- a/src/packages/generate-license-file/src/lib/models/license.ts
+++ b/src/packages/generate-license-file/src/lib/models/license.ts
@@ -20,7 +20,7 @@ export interface ILicense {
   /**
    * Notices for the license.
    */
-  notices: string | null;
+  notices: string[];
 
   /**
    * List of node packages that this license applies to.
@@ -30,10 +30,10 @@ export interface ILicense {
 
 export class License implements ILicense {
   public content: string;
-  public notices: string | null;
+  public notices: string[];
   public dependencies: string[];
 
-  public constructor(content: string, notices: string | null, dependencies: string[]) {
+  public constructor(content: string, notices: string[], dependencies: string[]) {
     this.content = content;
     this.notices = notices;
     this.dependencies = dependencies;
@@ -46,9 +46,15 @@ export class License implements ILicense {
       this.midfix(lineEnding) +
       prepareContentForOutput(this.content.trim(), lineEnding);
 
-    if (this.notices !== null) {
+    if (this.notices.length > 0) {
+      const noticeContent = this.notices.map(notice => notice.trim()).join(lineEnding);
+
+      console.log(noticeContent);
+
+      // Append the notices to the formatted text, preparing content for output to ensure
+      // the line endings inside each notice content are consistent.
       formattedText +=
-        this.noticesPrefix(lineEnding) + prepareContentForOutput(this.notices.trim(), lineEnding);
+        this.noticesPrefix(lineEnding) + prepareContentForOutput(noticeContent, lineEnding);
     }
 
     return formattedText;

--- a/src/packages/generate-license-file/src/lib/models/license.ts
+++ b/src/packages/generate-license-file/src/lib/models/license.ts
@@ -4,8 +4,9 @@ import { prepareContentForOutput } from "../utils/string.utils";
 const BULLET = " - ";
 const PREFIX = "The following npm package may be included in this product:";
 const PREFIX_PLURAL = "The following npm packages may be included in this product:";
-const MIDFIX = "This package contains the following license and notice below:";
-const MIDFIX_PLURAL = "These packages each contain the following license and notice below:";
+const MIDFIX = "This package contains the following license:";
+const MIDFIX_PLURAL = "These packages each contain the following license:";
+const NOTICES_PREFIX = "With the following notices:";
 
 /**
  * ILicense contains the content of a given license and the list of dependencies it pertains to.
@@ -17,6 +18,11 @@ export interface ILicense {
   content: string;
 
   /**
+   * Notices for the license.
+   */
+  notices: string | null;
+
+  /**
    * List of node packages that this license applies to.
    */
   dependencies: string[];
@@ -24,19 +30,26 @@ export interface ILicense {
 
 export class License implements ILicense {
   public content: string;
+  public notices: string | null;
   public dependencies: string[];
 
-  public constructor(content: string, dependencies: string[]) {
+  public constructor(content: string, notices: string | null, dependencies: string[]) {
     this.content = content;
+    this.notices = notices;
     this.dependencies = dependencies;
   }
 
   public format(lineEnding: LineEndingCharacters): string {
-    const formattedText =
+    let formattedText =
       this.prefix(lineEnding) +
       this.formatDependencies(lineEnding) +
       this.midfix(lineEnding) +
       prepareContentForOutput(this.content.trim(), lineEnding);
+
+    if (this.notices !== null) {
+      formattedText +=
+        this.noticesPrefix(lineEnding) + prepareContentForOutput(this.notices.trim(), lineEnding);
+    }
 
     return formattedText;
   }
@@ -47,6 +60,10 @@ export class License implements ILicense {
     }
 
     return PREFIX_PLURAL + EOL + EOL;
+  }
+
+  private noticesPrefix(EOL: string): string {
+    return EOL + EOL + NOTICES_PREFIX + EOL + EOL;
   }
 
   private formatDependencies(EOL: string): string {

--- a/src/packages/generate-license-file/src/lib/models/license.ts
+++ b/src/packages/generate-license-file/src/lib/models/license.ts
@@ -49,8 +49,6 @@ export class License implements ILicense {
     if (this.notices.length > 0) {
       const noticeContent = this.notices.map(notice => notice.trim()).join(lineEnding);
 
-      console.log(noticeContent);
-
       // Append the notices to the formatted text, preparing content for output to ensure
       // the line endings inside each notice content are consistent.
       formattedText +=

--- a/src/packages/generate-license-file/test/getLicenseFileText.spec.ts
+++ b/src/packages/generate-license-file/test/getLicenseFileText.spec.ts
@@ -84,8 +84,6 @@ describe("getLicenseFileText", () => {
 
     const result = await getLicenseFileText("path");
 
-    console.log({ result });
-
     const indexOfLicense1 = result.indexOf("a: license");
     const indexOfLicense2 = result.indexOf("b: license");
     const indexOfLicense3 = result.indexOf("c: license");

--- a/src/packages/generate-license-file/test/getLicenseFileText.spec.ts
+++ b/src/packages/generate-license-file/test/getLicenseFileText.spec.ts
@@ -75,9 +75,9 @@ describe("getLicenseFileText", () => {
 
   it("should sort the licenses by license content", async () => {
     const licenses: ResolvedLicense[] = [
-      { licenseContent: "b: license", dependencies: [] },
-      { licenseContent: "c: license", dependencies: [] },
-      { licenseContent: "a: license", dependencies: [] },
+      { licenseContent: "b: license", noticeContent: "notice", dependencies: [] },
+      { licenseContent: "c: license", noticeContent: "notice", dependencies: [] },
+      { licenseContent: "a: license", noticeContent: "notice", dependencies: [] },
     ];
 
     mockedResolveLicenses.mockResolvedValue(licenses);
@@ -98,6 +98,7 @@ describe("getLicenseFileText", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
+        noticeContent: "notice",
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },
@@ -117,6 +118,7 @@ describe("getLicenseFileText", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
+        noticeContent: "notice",
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },

--- a/src/packages/generate-license-file/test/getLicenseFileText.spec.ts
+++ b/src/packages/generate-license-file/test/getLicenseFileText.spec.ts
@@ -75,9 +75,9 @@ describe("getLicenseFileText", () => {
 
   it("should sort the licenses by license content", async () => {
     const licenses: ResolvedLicense[] = [
-      { licenseContent: "b: license", noticeContent: "notice", dependencies: [] },
-      { licenseContent: "c: license", noticeContent: "notice", dependencies: [] },
-      { licenseContent: "a: license", noticeContent: "notice", dependencies: [] },
+      { licenseContent: "b: license", notices: [], dependencies: [] },
+      { licenseContent: "c: license", notices: [], dependencies: [] },
+      { licenseContent: "a: license", notices: [], dependencies: [] },
     ];
 
     mockedResolveLicenses.mockResolvedValue(licenses);
@@ -98,7 +98,7 @@ describe("getLicenseFileText", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
-        noticeContent: "notice",
+        notices: [],
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },
@@ -118,7 +118,7 @@ describe("getLicenseFileText", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
-        noticeContent: "notice",
+        notices: [],
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },

--- a/src/packages/generate-license-file/test/getProjectLicenses.spec.ts
+++ b/src/packages/generate-license-file/test/getProjectLicenses.spec.ts
@@ -47,6 +47,7 @@ describe("getProjectLicenses", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
+        noticeContent: "notice",
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },
@@ -54,6 +55,7 @@ describe("getProjectLicenses", () => {
       },
       {
         licenseContent: "also stuff",
+        noticeContent: "notice",
         dependencies: [
           { name: "c", version: "3.0.0" },
           { name: "d", version: "4.0.0" },
@@ -68,6 +70,7 @@ describe("getProjectLicenses", () => {
     for (let i = 0; i < licenses.length; i++) {
       expect(result[i]).toEqual({
         content: licenses[i].licenseContent,
+        notices: licenses[i].noticeContent,
         dependencies: expect.anything(),
       });
     }
@@ -77,6 +80,7 @@ describe("getProjectLicenses", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
+        noticeContent: "notice",
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },
@@ -99,6 +103,7 @@ describe("getProjectLicenses", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
+        noticeContent: "notice",
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },

--- a/src/packages/generate-license-file/test/getProjectLicenses.spec.ts
+++ b/src/packages/generate-license-file/test/getProjectLicenses.spec.ts
@@ -47,7 +47,7 @@ describe("getProjectLicenses", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
-        noticeContent: "notice",
+        notices: [],
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },
@@ -55,7 +55,7 @@ describe("getProjectLicenses", () => {
       },
       {
         licenseContent: "also stuff",
-        noticeContent: "notice",
+        notices: [],
         dependencies: [
           { name: "c", version: "3.0.0" },
           { name: "d", version: "4.0.0" },
@@ -70,7 +70,7 @@ describe("getProjectLicenses", () => {
     for (let i = 0; i < licenses.length; i++) {
       expect(result[i]).toEqual({
         content: licenses[i].licenseContent,
-        notices: licenses[i].noticeContent,
+        notices: licenses[i].notices,
         dependencies: expect.anything(),
       });
     }
@@ -80,7 +80,7 @@ describe("getProjectLicenses", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
-        noticeContent: "notice",
+        notices: [],
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },
@@ -103,7 +103,7 @@ describe("getProjectLicenses", () => {
     const licenses: ResolvedLicense[] = [
       {
         licenseContent: "stuff",
-        noticeContent: "notice",
+        notices: [],
         dependencies: [
           { name: "a", version: "1.0.0" },
           { name: "b", version: "2.0.0" },

--- a/src/packages/generate-license-file/test/internal/resolveDependencies/resolveNpmDependencies.spec.ts
+++ b/src/packages/generate-license-file/test/internal/resolveDependencies/resolveNpmDependencies.spec.ts
@@ -3,7 +3,7 @@ import { when } from "jest-when";
 import { join } from "path";
 import { resolveDependenciesForNpmProject } from "../../../src/lib/internal/resolveDependencies/resolveNpmDependencies";
 import { resolveLicenseContent } from "../../../src/lib/internal/resolveLicenseContent";
-import { Dependency, LicenseContent } from "../../../src/lib/internal/resolveLicenses";
+import { LicenseNoticePair, ResolvedLicense } from "../../../src/lib/internal/resolveLicenses";
 import logger from "../../../src/lib/utils/console.utils";
 import { doesFileExist, readFile } from "../../../src/lib/utils/file.utils";
 import { PackageJson } from "../../../src/lib/utils/packageJson.utils";
@@ -29,36 +29,43 @@ describe("resolveNpmDependencies", () => {
   const child1Version = "1.0.0";
   const child1Realpath = "/some/path/child1";
   const child1LicenseContent = "license contents for child1 and child1.2";
+  const child1LicenseNoticePair: LicenseNoticePair = `${child1LicenseContent}:`;
 
   const child1_1Name = "child1.1";
   const child1_1Version = "1.1.0";
   const child1_1Realpath = "/some/path/child1.1";
   const child1_1LicenseContent = "license contents for child1.1";
+  const child1_1LicenseNoticePair: LicenseNoticePair = `${child1_1LicenseContent}:`;
 
   const child1_2Name = "child1.2";
   const child1_2Version = "1.2.0";
   const child1_2Realpath = "/some/path/child1.2";
   const child1_2LicenseContent = child1LicenseContent;
+  const child1_2LicenseNoticePair: LicenseNoticePair = `${child1_2LicenseContent}:`;
 
   const child2Name = "child2";
   const child2Version = "2.0.0";
   const child2Realpath = "/some/path/child2";
   const child2LicenseContent = "license contents for child2";
+  const child2LicenseNoticePair: LicenseNoticePair = `${child2LicenseContent}:`;
 
   const child2_1Name = "child2.1";
   const child2_1Version = "2.1.0";
   const child2_1Realpath = "/some/path/child2.1";
   const child2_1LicenseContent = "license contents for child2.1";
+  const child2_1LicenseNoticePair: LicenseNoticePair = `${child2_1LicenseContent}:`;
 
   const child3Name = "child3";
   const child3Version = "3.0.0";
   const child3Realpath = "/some/path/child3";
   const child3LicenseContent = "license contents for child3";
+  const child3LicenseNoticePair: LicenseNoticePair = `${child3LicenseContent}:`;
 
   const child3_1Name = "child3.1";
   const child3_1Version = "3.1.0";
   const child3_1Realpath = "/some/path/child3.1";
   const child3_1LicenseContent = "license contents for child3.1";
+  const child3_1LicenseNoticePair: LicenseNoticePair = `${child3_1LicenseContent}:`;
 
   // A node tree where:
   // - child1 is a 'normal' dependency
@@ -279,78 +286,86 @@ describe("resolveNpmDependencies", () => {
 
   describe("when no options are provided", () => {
     it("should include non-dev dependencies in the result", async () => {
-      const licensesMap = new Map<LicenseContent, Dependency[]>();
+      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap);
 
-      const child1LicenseContentMap = licensesMap.get(child1LicenseContent);
-      expect(child1LicenseContentMap?.find(c => c.name === child1Name)).toBeDefined();
+      const child1LicenseContentMap = licensesMap.get(child1LicenseNoticePair);
+      expect(child1LicenseContentMap?.dependencies.find(c => c.name === child1Name)).toBeDefined();
 
-      const child1_1LicenseContentMap = licensesMap.get(child1_1LicenseContent);
-      expect(child1_1LicenseContentMap?.find(c => c.name === child1_1Name)).toBeDefined();
+      const child1_1LicenseContentMap = licensesMap.get(child1_1LicenseNoticePair);
+      expect(
+        child1_1LicenseContentMap?.dependencies.find(c => c.name === child1_1Name),
+      ).toBeDefined();
 
-      const child1_2LicenseContentMap = licensesMap.get(child1_2LicenseContent);
-      expect(child1_2LicenseContentMap?.find(c => c.name === child1_2Name)).toBeDefined();
+      const child1_2LicenseContentMap = licensesMap.get(child1_2LicenseNoticePair);
+      expect(
+        child1_2LicenseContentMap?.dependencies.find(c => c.name === child1_2Name),
+      ).toBeDefined();
     });
 
     it("should not include dev dependencies in the result", async () => {
-      const licensesMap = new Map<LicenseContent, Dependency[]>();
+      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap);
 
-      const child2LicenseContentMap = licensesMap.get(child2LicenseContent);
+      const child2LicenseContentMap = licensesMap.get(child2LicenseNoticePair);
       expect(child2LicenseContentMap).toBeUndefined();
 
-      const child2_1LicenseContentMap = licensesMap.get(child2_1LicenseContent);
+      const child2_1LicenseContentMap = licensesMap.get(child2_1LicenseNoticePair);
       expect(child2_1LicenseContentMap).toBeUndefined();
     });
 
     it("should not include peer dependencies in the result", async () => {
-      const licensesMap = new Map<LicenseContent, Dependency[]>();
+      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap);
 
-      const child3LicenseContentMap = licensesMap.get(child3LicenseContent);
+      const child3LicenseContentMap = licensesMap.get(child3LicenseNoticePair);
       expect(child3LicenseContentMap).toBeUndefined();
 
-      const child3_1LicenseContentMap = licensesMap.get(child3_1LicenseContent);
+      const child3_1LicenseContentMap = licensesMap.get(child3_1LicenseNoticePair);
       expect(child3_1LicenseContentMap).toBeUndefined();
     });
   });
 
   describe("when a dependency is in the exclude list", () => {
     it("should not include the dependency in the result", async () => {
-      const licensesMap = new Map<LicenseContent, Dependency[]>();
+      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap, {
         exclude: [`${child1_1Name}@${child1_1Version}`],
       });
 
-      const child1LicenseContentMap = licensesMap.get(child1LicenseContent);
-      expect(child1LicenseContentMap?.find(c => c.name === child1Name)).toBeDefined();
+      const child1LicenseContentMap = licensesMap.get(child1LicenseNoticePair);
+      expect(child1LicenseContentMap?.dependencies.find(c => c.name === child1Name)).toBeDefined();
 
-      const child1_1LicenseContentMap = licensesMap.get(child1_1LicenseContent);
+      const child1_1LicenseContentMap = licensesMap.get(child1_1LicenseNoticePair);
       expect(child1_1LicenseContentMap).toBeUndefined();
 
-      const child1_2LicenseContentMap = licensesMap.get(child1_2LicenseContent);
-      expect(child1_2LicenseContentMap?.find(c => c.name === child1_2Name)).toBeDefined();
+      const child1_2LicenseContentMap = licensesMap.get(child1_2LicenseNoticePair);
+      expect(
+        child1_2LicenseContentMap?.dependencies.find(c => c.name === child1_2Name),
+      ).toBeDefined();
     });
 
     it("should not include the dependency in the result if specified by name only", async () => {
-      const licensesMap = new Map<LicenseContent, Dependency[]>();
+      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap, {
         exclude: [`${child1_1Name}`],
       });
 
-      const child1LicenseContentMap = licensesMap.get(child1LicenseContent);
-      expect(child1LicenseContentMap?.find(c => c.name === child1Name)).toBeDefined();
+      const child1LicenseContentMap = licensesMap.get(child1LicenseNoticePair);
+      expect(child1LicenseContentMap?.dependencies.find(c => c.name === child1Name)).toBeDefined();
 
-      const child1_1LicenseContentMap = licensesMap.get(child1_1LicenseContent);
+      const child1_1LicenseContentMap = licensesMap.get(child1_1LicenseNoticePair);
       expect(child1_1LicenseContentMap).toBeUndefined();
 
-      const child1_2LicenseContentMap = licensesMap.get(child1_2LicenseContent);
-      expect(child1_2LicenseContentMap?.find(c => c.name === child1_2Name)).toBeDefined();
+      const child1_2LicenseContentMap = licensesMap.get(child1_2LicenseNoticePair);
+      expect(
+        child1_2LicenseContentMap?.dependencies.find(c => c.name === child1_2Name),
+      ).toBeDefined();
     });
   });
 

--- a/src/packages/generate-license-file/test/internal/resolveDependencies/resolveNpmDependencies.spec.ts
+++ b/src/packages/generate-license-file/test/internal/resolveDependencies/resolveNpmDependencies.spec.ts
@@ -3,7 +3,7 @@ import { when } from "jest-when";
 import { join } from "path";
 import { resolveDependenciesForNpmProject } from "../../../src/lib/internal/resolveDependencies/resolveNpmDependencies";
 import { resolveLicenseContent } from "../../../src/lib/internal/resolveLicenseContent";
-import { LicenseNoticePair, ResolvedLicense } from "../../../src/lib/internal/resolveLicenses";
+import { LicenseNoticeKey, ResolvedLicense } from "../../../src/lib/internal/resolveLicenses";
 import logger from "../../../src/lib/utils/console.utils";
 import { doesFileExist, readFile } from "../../../src/lib/utils/file.utils";
 import { PackageJson } from "../../../src/lib/utils/packageJson.utils";
@@ -29,43 +29,43 @@ describe("resolveNpmDependencies", () => {
   const child1Version = "1.0.0";
   const child1Realpath = "/some/path/child1";
   const child1LicenseContent = "license contents for child1 and child1.2";
-  const child1LicenseNoticePair: LicenseNoticePair = `${child1LicenseContent}:`;
+  const child1LicenseNoticePair: LicenseNoticeKey = `${child1LicenseContent}:`;
 
   const child1_1Name = "child1.1";
   const child1_1Version = "1.1.0";
   const child1_1Realpath = "/some/path/child1.1";
   const child1_1LicenseContent = "license contents for child1.1";
-  const child1_1LicenseNoticePair: LicenseNoticePair = `${child1_1LicenseContent}:`;
+  const child1_1LicenseNoticePair: LicenseNoticeKey = `${child1_1LicenseContent}:`;
 
   const child1_2Name = "child1.2";
   const child1_2Version = "1.2.0";
   const child1_2Realpath = "/some/path/child1.2";
   const child1_2LicenseContent = child1LicenseContent;
-  const child1_2LicenseNoticePair: LicenseNoticePair = `${child1_2LicenseContent}:`;
+  const child1_2LicenseNoticePair: LicenseNoticeKey = `${child1_2LicenseContent}:`;
 
   const child2Name = "child2";
   const child2Version = "2.0.0";
   const child2Realpath = "/some/path/child2";
   const child2LicenseContent = "license contents for child2";
-  const child2LicenseNoticePair: LicenseNoticePair = `${child2LicenseContent}:`;
+  const child2LicenseNoticePair: LicenseNoticeKey = `${child2LicenseContent}:`;
 
   const child2_1Name = "child2.1";
   const child2_1Version = "2.1.0";
   const child2_1Realpath = "/some/path/child2.1";
   const child2_1LicenseContent = "license contents for child2.1";
-  const child2_1LicenseNoticePair: LicenseNoticePair = `${child2_1LicenseContent}:`;
+  const child2_1LicenseNoticePair: LicenseNoticeKey = `${child2_1LicenseContent}:`;
 
   const child3Name = "child3";
   const child3Version = "3.0.0";
   const child3Realpath = "/some/path/child3";
   const child3LicenseContent = "license contents for child3";
-  const child3LicenseNoticePair: LicenseNoticePair = `${child3LicenseContent}:`;
+  const child3LicenseNoticePair: LicenseNoticeKey = `${child3LicenseContent}:`;
 
   const child3_1Name = "child3.1";
   const child3_1Version = "3.1.0";
   const child3_1Realpath = "/some/path/child3.1";
   const child3_1LicenseContent = "license contents for child3.1";
-  const child3_1LicenseNoticePair: LicenseNoticePair = `${child3_1LicenseContent}:`;
+  const child3_1LicenseNoticePair: LicenseNoticeKey = `${child3_1LicenseContent}:`;
 
   // A node tree where:
   // - child1 is a 'normal' dependency
@@ -286,7 +286,7 @@ describe("resolveNpmDependencies", () => {
 
   describe("when no options are provided", () => {
     it("should include non-dev dependencies in the result", async () => {
-      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
+      const licensesMap = new Map<LicenseNoticeKey, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap);
 
@@ -305,7 +305,7 @@ describe("resolveNpmDependencies", () => {
     });
 
     it("should not include dev dependencies in the result", async () => {
-      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
+      const licensesMap = new Map<LicenseNoticeKey, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap);
 
@@ -317,7 +317,7 @@ describe("resolveNpmDependencies", () => {
     });
 
     it("should not include peer dependencies in the result", async () => {
-      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
+      const licensesMap = new Map<LicenseNoticeKey, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap);
 
@@ -331,7 +331,7 @@ describe("resolveNpmDependencies", () => {
 
   describe("when a dependency is in the exclude list", () => {
     it("should not include the dependency in the result", async () => {
-      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
+      const licensesMap = new Map<LicenseNoticeKey, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap, {
         exclude: [`${child1_1Name}@${child1_1Version}`],
@@ -350,7 +350,7 @@ describe("resolveNpmDependencies", () => {
     });
 
     it("should not include the dependency in the result if specified by name only", async () => {
-      const licensesMap = new Map<LicenseNoticePair, ResolvedLicense>();
+      const licensesMap = new Map<LicenseNoticeKey, ResolvedLicense>();
 
       await resolveDependenciesForNpmProject("/some/path/package.json", licensesMap, {
         exclude: [`${child1_1Name}`],

--- a/src/packages/generate-license-file/test/internal/resolveDependencies/resolvePnpmDependencies.spec.ts
+++ b/src/packages/generate-license-file/test/internal/resolveDependencies/resolvePnpmDependencies.spec.ts
@@ -1,9 +1,9 @@
 ﻿import { when } from "jest-when";
-import { resolveNoticeContent } from "packages/generate-license-file/src/lib/internal/resolveNoticeContent";
 import { join } from "path";
 import { resolveDependenciesForPnpmProject } from "../../../src/lib/internal/resolveDependencies/resolvePnpmDependencies";
 import { resolveLicenseContent } from "../../../src/lib/internal/resolveLicenseContent";
 import { LicenseNoticePair, ResolvedLicense } from "../../../src/lib/internal/resolveLicenses";
+import { resolveNoticeContent } from "../../../src/lib/internal/resolveNoticeContent";
 import logger from "../../../src/lib/utils/console.utils";
 import { doesFileExist, readFile } from "../../../src/lib/utils/file.utils";
 import { PackageJson } from "../../../src/lib/utils/packageJson.utils";

--- a/src/packages/generate-license-file/test/internal/resolveNoticeContent/index.spec.ts
+++ b/src/packages/generate-license-file/test/internal/resolveNoticeContent/index.spec.ts
@@ -1,0 +1,68 @@
+import { glob } from "glob";
+import { when } from "jest-when";
+import { ResolutionInputs } from "../../../src/lib/internal/resolveLicenseContent";
+import { resolveNoticeContent } from "../../../src/lib/internal/resolveNoticeContent";
+import logger from "../../../src/lib/utils/console.utils";
+import { readFile } from "../../../src/lib/utils/file.utils";
+
+jest.mock("glob", () => ({
+  glob: jest.fn(),
+}));
+
+jest.mock("../../../src/lib/utils/file.utils");
+jest.mock("../../../src/lib/utils/console.utils"); // Stops logger.warn from being called
+
+describe("resolveNoticeContent", () => {
+  const mockedGlob = jest.mocked(glob);
+  const mockedReadFile = jest.mocked(readFile);
+  const mockedWarn = jest.mocked(logger.warn);
+
+  const resolutionInputs: ResolutionInputs = {
+    directory: "/some/directory",
+    packageJson: {
+      name: "some-package",
+      version: "1.0.0",
+    },
+  };
+
+  beforeEach(jest.resetAllMocks);
+  afterAll(jest.restoreAllMocks);
+
+  it("should return null if no license files are found", async () => {
+    mockedGlob.mockResolvedValue([]);
+
+    const result = await resolveNoticeContent(resolutionInputs);
+
+    expect(result).toBeNull();
+  });
+
+  it("should return the contents of the first notice file found", async () => {
+    const noticeFilePath = `${resolutionInputs.directory}/notice.txt`;
+
+    mockedGlob.mockResolvedValue([noticeFilePath, "some/other/file.txt"]);
+    when(mockedReadFile)
+      .calledWith(noticeFilePath, { encoding: "utf-8" })
+      .mockResolvedValue("Notice contents");
+
+    const result = await resolveNoticeContent(resolutionInputs);
+
+    expect(mockedReadFile).toHaveBeenCalledTimes(1);
+    expect(mockedReadFile).toHaveBeenCalledWith(noticeFilePath, { encoding: "utf-8" });
+    expect(result).toBe("Notice contents");
+  });
+
+  it("should warning log if multiple files are found", async () => {
+    const noticeFilePath = `${resolutionInputs.directory}/notice.txt`;
+
+    mockedGlob.mockResolvedValue([noticeFilePath, "some/other/file.txt"]);
+    when(mockedReadFile)
+      .calledWith(noticeFilePath, { encoding: "utf-8" })
+      .mockResolvedValue("Notice contents");
+
+    expect(mockedWarn).toHaveBeenCalledTimes(0);
+
+    await resolveNoticeContent(resolutionInputs);
+
+    expect(mockedWarn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/packages/generate-license-file/test/internal/resolveNoticeContent/index.spec.ts
+++ b/src/packages/generate-license-file/test/internal/resolveNoticeContent/index.spec.ts
@@ -1,7 +1,6 @@
 import { glob } from "glob";
 import { when } from "jest-when";
 import { resolveNotices } from "../../../src/lib/internal/resolveNoticeContent";
-import logger from "../../../src/lib/utils/console.utils";
 import { readFile } from "../../../src/lib/utils/file.utils";
 
 jest.mock("glob", () => ({
@@ -14,7 +13,6 @@ jest.mock("../../../src/lib/utils/console.utils"); // Stops logger.warn from bei
 describe("resolveNoticeContent", () => {
   const mockedGlob = jest.mocked(glob);
   const mockedReadFile = jest.mocked(readFile);
-  const mockedWarn = jest.mocked(logger.warn);
 
   const directory = "/some/directory";
 

--- a/src/packages/generate-license-file/test/internal/resolveNoticeContent/index.spec.ts
+++ b/src/packages/generate-license-file/test/internal/resolveNoticeContent/index.spec.ts
@@ -1,7 +1,6 @@
 import { glob } from "glob";
 import { when } from "jest-when";
-import { ResolutionInputs } from "../../../src/lib/internal/resolveLicenseContent";
-import { resolveNoticeContent } from "../../../src/lib/internal/resolveNoticeContent";
+import { resolveNotices } from "../../../src/lib/internal/resolveNoticeContent";
 import logger from "../../../src/lib/utils/console.utils";
 import { readFile } from "../../../src/lib/utils/file.utils";
 
@@ -17,52 +16,52 @@ describe("resolveNoticeContent", () => {
   const mockedReadFile = jest.mocked(readFile);
   const mockedWarn = jest.mocked(logger.warn);
 
-  const resolutionInputs: ResolutionInputs = {
-    directory: "/some/directory",
-    packageJson: {
-      name: "some-package",
-      version: "1.0.0",
-    },
-  };
+  const directory = "/some/directory";
 
   beforeEach(jest.resetAllMocks);
   afterAll(jest.restoreAllMocks);
 
-  it("should return null if no license files are found", async () => {
+  it("should return empty array if no license files are found", async () => {
     mockedGlob.mockResolvedValue([]);
 
-    const result = await resolveNoticeContent(resolutionInputs);
+    const result = await resolveNotices(directory);
 
-    expect(result).toBeNull();
+    expect(result).toBeInstanceOf(Array);
+    expect(result).toHaveLength(0);
   });
 
-  it("should return the contents of the first notice file found", async () => {
-    const noticeFilePath = `${resolutionInputs.directory}/notice.txt`;
+  it("should return the contents of the notice file found", async () => {
+    const noticeFilePath = `${directory}/notice.txt`;
 
-    mockedGlob.mockResolvedValue([noticeFilePath, "some/other/file.txt"]);
+    mockedGlob.mockResolvedValue([noticeFilePath]);
     when(mockedReadFile)
       .calledWith(noticeFilePath, { encoding: "utf-8" })
       .mockResolvedValue("Notice contents");
 
-    const result = await resolveNoticeContent(resolutionInputs);
+    const result = await resolveNotices(directory);
 
     expect(mockedReadFile).toHaveBeenCalledTimes(1);
     expect(mockedReadFile).toHaveBeenCalledWith(noticeFilePath, { encoding: "utf-8" });
-    expect(result).toBe("Notice contents");
+    expect(result).toStrictEqual(["Notice contents"]);
   });
 
-  it("should warning log if multiple files are found", async () => {
-    const noticeFilePath = `${resolutionInputs.directory}/notice.txt`;
+  it("should return a list of notice file contents if multiple files are found", async () => {
+    const noticeFilePath1 = `${directory}/notice.txt`;
+    const noticeFilePath2 = `${directory}/notice2.txt`;
 
-    mockedGlob.mockResolvedValue([noticeFilePath, "some/other/file.txt"]);
+    mockedGlob.mockResolvedValue([noticeFilePath1, noticeFilePath2]);
     when(mockedReadFile)
-      .calledWith(noticeFilePath, { encoding: "utf-8" })
-      .mockResolvedValue("Notice contents");
+      .calledWith(noticeFilePath1, { encoding: "utf-8" })
+      .mockResolvedValue("Notice contents 1");
+    when(mockedReadFile)
+      .calledWith(noticeFilePath2, { encoding: "utf-8" })
+      .mockResolvedValue("Notice contents 2");
 
-    expect(mockedWarn).toHaveBeenCalledTimes(0);
+    const result = await resolveNotices(directory);
 
-    await resolveNoticeContent(resolutionInputs);
-
-    expect(mockedWarn).toHaveBeenCalledTimes(1);
+    expect(mockedReadFile).toHaveBeenCalledTimes(2);
+    expect(mockedReadFile).toHaveBeenCalledWith(noticeFilePath1, { encoding: "utf-8" });
+    expect(mockedReadFile).toHaveBeenCalledWith(noticeFilePath2, { encoding: "utf-8" });
+    expect(result).toStrictEqual(["Notice contents 1", "Notice contents 2"]);
   });
 });

--- a/src/packages/generate-license-file/test/models/license.spec.ts
+++ b/src/packages/generate-license-file/test/models/license.spec.ts
@@ -13,7 +13,7 @@ describe("License", () => {
     const prefix = "The following npm packages may be included in this product:";
 
     it("should prefix the license", () => {
-      const license = new License("", []);
+      const license = new License("", null, []);
 
       const result = license.format("\n");
 
@@ -23,7 +23,7 @@ describe("License", () => {
     it.each(lineEndings)("should use the %s line ending twice after the prefix", lineEnding => {
       const eol = getLineEndingCharacters(lineEnding);
 
-      const license = new License("", []);
+      const license = new License("", null, []);
 
       const result = license.format(eol);
       const resultWithoutPrefix = result.substring(prefix.length);
@@ -32,7 +32,7 @@ describe("License", () => {
     });
 
     it("should list all of the dependencies", () => {
-      const license = new License("", dependencies);
+      const license = new License("", null, dependencies);
 
       const result = license.format("\n");
       const resultLines = result.split("\n");
@@ -50,7 +50,7 @@ describe("License", () => {
 
         const lastDep = "last dep";
         const lastDepOnly = [lastDep];
-        const license = new License("", lastDepOnly);
+        const license = new License("", null, lastDepOnly);
 
         const result = license.format(eol);
         const indexOfLastDependency = result.lastIndexOf(lastDep);
@@ -63,7 +63,7 @@ describe("License", () => {
     it("should end with the license content", () => {
       const theLicenseContent = "The license content";
 
-      const license = new License(theLicenseContent, dependencies);
+      const license = new License(theLicenseContent, null, dependencies);
 
       const result = license.format("\n");
 
@@ -78,7 +78,7 @@ describe("License", () => {
         const originalLicenseContent = `The\rlicense\nfile\r\ncontent`;
         const expectedLicenseContent = `The${eol}license${eol}file${eol}content`;
 
-        const license = new License(originalLicenseContent, dependencies);
+        const license = new License(originalLicenseContent, null, dependencies);
 
         const result = license.format(eol);
 

--- a/src/packages/generate-license-file/test/models/license.spec.ts
+++ b/src/packages/generate-license-file/test/models/license.spec.ts
@@ -13,7 +13,7 @@ describe("License", () => {
     const prefix = "The following npm packages may be included in this product:";
 
     it("should prefix the license", () => {
-      const license = new License("", null, []);
+      const license = new License("", [], []);
 
       const result = license.format("\n");
 
@@ -23,7 +23,7 @@ describe("License", () => {
     it.each(lineEndings)("should use the %s line ending twice after the prefix", lineEnding => {
       const eol = getLineEndingCharacters(lineEnding);
 
-      const license = new License("", null, []);
+      const license = new License("", [], []);
 
       const result = license.format(eol);
       const resultWithoutPrefix = result.substring(prefix.length);
@@ -32,7 +32,7 @@ describe("License", () => {
     });
 
     it("should list all of the dependencies", () => {
-      const license = new License("", null, dependencies);
+      const license = new License("", [], dependencies);
 
       const result = license.format("\n");
       const resultLines = result.split("\n");
@@ -50,7 +50,7 @@ describe("License", () => {
 
         const lastDep = "last dep";
         const lastDepOnly = [lastDep];
-        const license = new License("", null, lastDepOnly);
+        const license = new License("", [], lastDepOnly);
 
         const result = license.format(eol);
         const indexOfLastDependency = result.lastIndexOf(lastDep);
@@ -63,11 +63,21 @@ describe("License", () => {
     it("should end with the license content", () => {
       const theLicenseContent = "The license content";
 
-      const license = new License(theLicenseContent, null, dependencies);
+      const license = new License(theLicenseContent, [], dependencies);
 
       const result = license.format("\n");
 
       expect(result.endsWith(theLicenseContent)).toBeTruthy();
+    });
+
+    it("should contain the notice content", () => {
+      const theNoticeContent = "The notice content";
+
+      const license = new License("", [theNoticeContent], dependencies);
+
+      const result = license.format("\n");
+
+      expect(result.includes(theNoticeContent)).toBeTruthy();
     });
 
     it.each(lineEndings)(
@@ -78,7 +88,7 @@ describe("License", () => {
         const originalLicenseContent = `The\rlicense\nfile\r\ncontent`;
         const expectedLicenseContent = `The${eol}license${eol}file${eol}content`;
 
-        const license = new License(originalLicenseContent, null, dependencies);
+        const license = new License(originalLicenseContent, [], dependencies);
 
         const result = license.format(eol);
 

--- a/src/packages/generate-license-file/test/models/license.spec.ts
+++ b/src/packages/generate-license-file/test/models/license.spec.ts
@@ -80,6 +80,22 @@ describe("License", () => {
       expect(result.includes(theNoticeContent)).toBeTruthy();
     });
 
+    it("should contain all notice contents if there are multiple", () => {
+      const theNoticeContent1 = "The notice content 1";
+      const theNoticeContent2 = "The notice content 2";
+
+      const license = new License("", [theNoticeContent1, theNoticeContent2], dependencies);
+
+      const result = license.format("\n");
+      const resultLines = result.split("\n");
+
+      const noticeOneIndex = resultLines.indexOf(theNoticeContent1);
+      const noticeTwoIndex = resultLines.indexOf(theNoticeContent2);
+
+      // The second notice should be after the first notice.
+      expect(noticeTwoIndex).toBeGreaterThan(noticeOneIndex);
+    });
+
     it.each(lineEndings)(
       "should normalise the line endings in the license content to %s",
       lineEnding => {


### PR DESCRIPTION
Add handling for `NOTICE` files in dependencies. If generate-license-file encounters any notice files when searching for a package's license, it will append it to the license output for the given package.

Adds a new `notices` array to the `ILicense` interface, containing a list of the notices content found.