### PR TITLE
Update the npm dependency resolution to traverse the dependency graph rather than the node_modules dir

### DIFF
--- a/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolveNpmDependencies.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolveNpmDependencies.ts
@@ -24,7 +24,14 @@ export const resolveDependenciesForNpmProject = async (
   const arborist = new Arborist({ path });
   const topNode = await arborist.loadActual();
 
+  const visitedNodes = new Set<Node | Link>();
+
   const parseNode = async (node: Node | Link) => {
+    if (visitedNodes.has(node)) {
+      return;
+    }
+    visitedNodes.add(node);
+
     if (node.dev || node.peer) {
       return;
     }
@@ -73,13 +80,19 @@ export const resolveDependenciesForNpmProject = async (
       logger.warn(warningLines.join("\n"));
     }
 
-    for (const child of node.children.values()) {
-      await parseNode(child);
+    for (const edgeOut of node.edgesOut.values()) {
+      const edgeNode = edgeOut.to;
+      if (edgeNode) {
+        await parseNode(edgeNode);
+      }
     }
   };
 
   for (const child of topNode.children.values()) {
-    await parseNode(child);
+    const isTopLevel = isTopLevelDependency(child);
+    if (isTopLevel) {
+      await parseNode(child);
+    }
   }
 };
 
@@ -87,4 +100,14 @@ const resolvePath = (path: string): string => {
   const absolutePackageJson = isAbsolute(path) ? path : join(process.cwd(), path);
 
   return dirname(absolutePackageJson);
+};
+
+const isTopLevelDependency = (node: Node | Link): boolean => {
+  for (const edge of node.edgesIn) {
+    if (edge.from?.isRoot) {
+      return true;
+    }
+  }
+
+  return false;
 };


### PR DESCRIPTION
This PR is precursor to being able to fix #597.
This PR changes the way that the npm dependency resolution algorithm parses node modules.

Previously it loaded in all the modules as they exist in the file system and then parsed them in order. Nested node modules were discovered using the recursive nature of the function.

Now the file instead only parses node modules if they're classified as "top-level", as in, one of their parent nodes is the root. The same recursive nature of the function is now used to in turn pass over all the other node modules that the current node depends on. This means that the function 'darts' around the top-level node modules as a graph, rather than as a flat list.

Once this change is merged, #597 can be fixed by refactoring the `isTopLevelDependency` function to only return true if the dependency is present in the package.json in the deeply-nested package.json within the mono-repo.