### PR TITLE
Add interactive terminal demo to README

### DIFF
--- a/.dg/.gitignore
+++ b/.dg/.gitignore
@@ -1,0 +1,3 @@
+# DeepGuide
+.dg/casts/
+.dg/svg/

--- a/.dg/README.md
+++ b/.dg/README.md
@@ -1,0 +1,9 @@
+# DeepGuide Integration
+
+This directory holds configuration and interactive demo assets for [DeepGuide](https://github.com/deepguide-ai/dg).
+
+To add your first demo, run:
+
+```bash
+npx @deepguide-ai/dg capture
+```

--- a/.dg/config.json
+++ b/.dg/config.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.1.0",
+  "project": "generate-license-file",
+  "outputDir": ".dg",
+  "casts": []
+}

--- a/.github/workflows/dg-validate.yml
+++ b/.github/workflows/dg-validate.yml
@@ -1,0 +1,28 @@
+name: DeepGuide
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  validate:
+    name: Validate Demos
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+      
+    - name: Install asciinema
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y asciinema
+    
+    - name: Validate demos
+      run: npx @deepguide-ai/dg validate --non-interactive


### PR DESCRIPTION
Hello!

I’ve been exploring your CLI project and wanted to help make it easier for users to understand and use. This PR sets up [DeepGuide](https://github.com/deepguide-ai/dg), a tool for recording interactive terminal demos directly in your README.

### What this PR does

- Adds a `.dg/` config directory and GitHub Actions workflow to your repo for demo recording and CI validation.
    
- No changes to your CLI code itself, only prepares your repo to capture demos.
    

### Next steps for you

After merging, DeepGuide is installed and configured. You can start recording demos by running:

`npx @deepguide-ai/dg doctor`
`npx @deepguide-ai/dg capture`

This generates interactive SVG demos that you can embed in your README or documentation. Commit these changes to update your docs with live, interactive examples.

### Why use [DeepGuide CLI](https://deepguide.ai/)?

- Make your CLI usage easier to follow with interactive, up-to-date demos.
    
- Avoid stale GIFs or static code blocks.
    
- Automatically validate demos in CI to keep docs accurate.