### PR TITLE
fix: support pnpm 11

### DIFF
--- a/.github/workflows/src-ci.yml
+++ b/.github/workflows/src-ci.yml
@@ -180,6 +180,7 @@ jobs:
         pnpm:
           - 9.15.4
           - 10.0.0
+          - 11.0.0
 
     name: E2E (pnpm ${{ matrix.pnpm }})
 

--- a/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolvePnpmDependencies.ts
+++ b/src/packages/generate-license-file/src/lib/internal/resolveDependencies/resolvePnpmDependencies.ts
@@ -76,6 +76,7 @@ export const resolveDependenciesForPnpmProject = async (
 };
 
 const allowedPnpmMinorVersions: Record<number, number> = {
+  11: 0,
   10: 0,
   9: 0,
   8: 0,
@@ -92,7 +93,7 @@ const verifyPnpmVersion = async () => {
 
   const errorLines = [
     `Unsupported pnpm version: ${pnpmVersion.major}.${pnpmVersion.minor}.${pnpmVersion.patch}.`,
-    "Generate license file currently only supports pnpm versions >=7.33.0 & >=8.0.0",
+    "Generate license file currently only supports pnpm versions >=7.33.0",
     "Please either switch to a supported version of pnpm or raise an issue on the generate-license-file repository for us to support your version of pnpm:",
     "https://github.com/TobyAndToby/generate-license-file",
   ];

--- a/src/packages/generate-license-file/test/internal/resolveDependencies/resolvePnpmDependencies.spec.ts
+++ b/src/packages/generate-license-file/test/internal/resolveDependencies/resolvePnpmDependencies.spec.ts
@@ -93,7 +93,7 @@ describe("resolveDependenciesForPnpmProject", () => {
 
       await expect(resolveDependenciesForPnpmProject).rejects.toThrow(
         "Unsupported pnpm version: 7.32.999.\n" +
-          "Generate license file currently only supports pnpm versions >=7.33.0 & >=8.0.0\n" +
+          "Generate license file currently only supports pnpm versions >=7.33.0\n" +
           "Please either switch to a supported version of pnpm or raise an issue on the generate-license-file repository for us to support your version of pnpm:\n" +
           "https://github.com/TobyAndToby/generate-license-file",
       );
@@ -111,6 +111,9 @@ describe("resolveDependenciesForPnpmProject", () => {
   describe.each([
     { major: 7, minor: 33, patch: 0 },
     { major: 8, minor: 0, patch: 0 },
+    { major: 9, minor: 0, patch: 0 },
+    { major: 10, minor: 0, patch: 0 },
+    { major: 11, minor: 0, patch: 0 },
   ])("when the pnpm version is a supported version (%p)", pnpmVersion => {
     it("should call getPnpmProjectDependencies", async () => {
       mockedGetPnpmVersion.mockResolvedValue(pnpmVersion);


### PR DESCRIPTION
## Summary

Adds support for pnpm 11 in the pnpm dependency resolver.

## Changes

- Add pnpm 11 to the supported pnpm version allowlist
- Update the unsupported-version error message
- Expand the pnpm version test matrix to include pnpm 9, 10, and 11

## Testing

- `npm run test`

Closes #718