### PR TITLE
fix(website): resolve Tabs typecheck errors, broken api anchors, and add CI gate

### DIFF
--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -39,7 +39,5 @@ jobs:
       - name: Typecheck
         run: bun run typecheck --filter='@generate-license-file/website'
 
-      # Builds with onBrokenLinks / onBrokenAnchors / onBrokenMarkdownLinks set to
-      # "throw" in docusaurus.config.js, so broken links and anchors fail the job.
       - name: Build
         run: bun run build --filter='@generate-license-file/website'

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -1,0 +1,45 @@
+name: Website CI
+
+on:
+  push:
+    branches:
+      - renovate/*
+      - main
+    paths:
+      - "apps/website/**"
+      - ".github/workflows/website-ci.yml"
+      - "turbo.json"
+      - "package.json"
+      - "bun.lock"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "apps/website/**"
+      - ".github/workflows/website-ci.yml"
+      - "turbo.json"
+      - "package.json"
+      - "bun.lock"
+
+jobs:
+  website:
+    name: Typecheck & Build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck --filter='@generate-license-file/website'
+
+      # Builds with onBrokenLinks / onBrokenAnchors / onBrokenMarkdownLinks set to
+      # "throw" in docusaurus.config.js, so broken links and anchors fail the job.
+      - name: Build
+        run: bun run build --filter='@generate-license-file/website'

--- a/apps/website/docusaurus.config.js
+++ b/apps/website/docusaurus.config.js
@@ -7,8 +7,14 @@ const config = {
   url: "https://generate-license-file.js.org",
   baseUrl: "/",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
+  onBrokenAnchors: "throw",
   favicon: "favicon.ico",
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    },
+  },
 
   organizationName: "TobyAndToby",
   projectName: "generate-license-file",

--- a/apps/website/src/components/Tabs/Tabs.tsx
+++ b/apps/website/src/components/Tabs/Tabs.tsx
@@ -17,7 +17,8 @@ const TabItem = styled.div<{ isActive: boolean }>`
 `;
 
 export const Tabs: FC<PropsWithChildren<Record<string, unknown>>> = ({ children }) => {
-  const [activeTabLabel, setActiveTabLabel] = useState(children[0].props.label);
+  const tabs = React.Children.toArray(children);
+  const [activeTabLabel, setActiveTabLabel] = useState((tabs[0] as any)?.props.label);
 
   return (
     <>

--- a/apps/website/versioned_docs/version-1.3.0/library/api.mdx
+++ b/apps/website/versioned_docs/version-1.3.0/library/api.mdx
@@ -127,7 +127,7 @@ import MethodTags from "@site/src/components/docs/library/api/MethodTags";
     <>
       Contains the content of a given license and the list of dependencies it pertains to. It is
       returned from{" "}
-      <a href="#getProjectLicenses">
+      <a href="#getprojectlicenses-">
         <code>getProjectLicenses</code>
       </a>
     </>

--- a/apps/website/versioned_docs/version-2.0.0/library/api.mdx
+++ b/apps/website/versioned_docs/version-2.0.0/library/api.mdx
@@ -174,7 +174,7 @@ import MethodTags from "@site/src/components/docs/library/api/MethodTags";
     <>
       Contains the content of a given license and the list of dependencies it pertains to. It is
       returned from{" "}
-      <a href="#getProjectLicenses">
+      <a href="#getprojectlicenses-">
         <code>getProjectLicenses</code>
       </a>
     </>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "bun@1.3.11",
   "scripts": {
     "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
     "build": "turbo run build",
     "test": "turbo run test --",
     "test:e2e": "turbo run e2e",

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,11 @@
       "inputs": ["src/**", "test/**", "{workspaceRoot}/biome.json"],
       "cache": true
     },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "docs/**", "versioned_docs/**", "tsconfig*.json"],
+      "cache": true
+    },
     "e2e": {
       "dependsOn": ["^build"],
       "cache": false


### PR DESCRIPTION
## What & why

The website had latent issues that no CI gate would catch, since the site is only built post-merge by `website-cd.yml` and typecheck wasn't wired into CI at all. This fixes the issues and adds a pre-merge guard so they can't regress.

### Fixes
- **`Tabs.tsx` typecheck errors** — `children[0].props.label` tripped two strict `tsc` errors (`children` possibly null/undefined; implicit `any` indexing a `ReactNode`). Normalised via `React.Children.toArray(...)` before reading the first tab's label.
- **Broken doc anchors** — the `1.3.0`/`2.0.0` versioned `api.mdx` linked to the old camelCase `#getProjectLicenses`; pointed them at the actual generated slug `#getprojectlicenses-` (matching `3.0.0`/`4.0.0`).

### CI guard
- Added a `typecheck` Turbo task + root script (`tsc`, website only for now).
- New **Website CI** workflow running typecheck + build on PRs that touch the website or shared build config.
- Set `onBrokenAnchors: "throw"` so broken anchors fail the build, and migrated `onBrokenMarkdownLinks` under `markdown.hooks` to clear the Docusaurus v4 deprecation warning.

## Testing
- `bun run typecheck --filter='@generate-license-file/website'` → pass (also verified clean, no `.docusaurus`)
- `bun run build --filter='@generate-license-file/website'` → pass, zero warnings
- Verified the guard fails: temporarily re-broke an anchor → build exited 1; restored → clean
- Repo lint 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)