### PR TITLE
ci: cycle node versions — drop 20, add 26

### DIFF
--- a/.github/workflows/src-ci.yml
+++ b/.github/workflows/src-ci.yml
@@ -104,9 +104,9 @@ jobs:
           - name: Windows
             value: windows-latest
         node:
-          - 20
           - 22
           - 24
+          - 26
 
     name: E2E (Node ${{ matrix.node }} on ${{ matrix.os.name }})
 


### PR DESCRIPTION
Cycles the E2E test matrix to keep a rolling three-version window, matching the previous cycling (drop oldest, add newest).

- Drop Node.js 20
- Add Node.js 26

Matrix is now `22, 24, 26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)