### PR TITLE
chore: disable renovate updates for ora

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>TobyAndToby/renovate-config"],
-  "stopUpdatingLabel": "parked"
+  "stopUpdatingLabel": "parked",
+  "packageRules": [
+    {
+      "matchPackageNames": ["ora"],
+      "enabled": false,
+      "description": "Pinned to v5 (CJS). Later majors are pure ESM; not worth the upgrade churn for now."
+    }
+  ]
 }


### PR DESCRIPTION
Pins `ora` to v5 (CJS) and tells Renovate to stop proposing updates.

ora v6+ is pure ESM and v9 requires a Node bump. We re-assessed and decided the upgrade isn't worth the churn for now, so this disables ora in `renovate.json`.

Supersedes / closes #664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)