### PR TITLE
fix: sort discovered license files for deterministic cross-platform output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
       "name": "@generate-license-file-e2e/npm-package",
       "version": "0.0.0",
       "dependencies": {
+        "dep-eight": "workspace:*",
         "dep-five": "workspace:*",
         "dep-four": "workspace:*",
         "dep-one": "workspace:*",
@@ -131,6 +132,10 @@
         "dep-two": "file:../test-dependencies/dep-two",
         "dep-two-duplicate": "file:../test-dependencies/dep-two-duplicate",
       },
+    },
+    "e2e/test-dependencies/dep-eight": {
+      "name": "dep-eight",
+      "version": "1.0.0",
     },
     "e2e/test-dependencies/dep-five": {
       "name": "dep-five",
@@ -1420,6 +1425,8 @@
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dep-eight": ["dep-eight@workspace:e2e/test-dependencies/dep-eight"],
 
     "dep-five": ["dep-five@workspace:e2e/test-dependencies/dep-five"],
 

--- a/e2e/multiple-inputs/test/cli/__snapshots__/index.e2e.spec.ts.snap
+++ b/e2e/multiple-inputs/test/cli/__snapshots__/index.e2e.spec.ts.snap
@@ -6,6 +6,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:

--- a/e2e/multiple-inputs/test/library/__snapshots__/generateLicenseFile.e2e.spec.ts.snap
+++ b/e2e/multiple-inputs/test/library/__snapshots__/generateLicenseFile.e2e.spec.ts.snap
@@ -6,6 +6,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:

--- a/e2e/multiple-inputs/test/library/__snapshots__/getLicenseFileText.e2e.spec.ts.snap
+++ b/e2e/multiple-inputs/test/library/__snapshots__/getLicenseFileText.e2e.spec.ts.snap
@@ -6,6 +6,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:

--- a/e2e/npm-package/package.json
+++ b/e2e/npm-package/package.json
@@ -13,7 +13,8 @@
     "dep-three": "workspace:*",
     "dep-four": "workspace:*",
     "dep-five": "workspace:*",
-    "dep-seven": "workspace:*"
+    "dep-seven": "workspace:*",
+    "dep-eight": "workspace:*"
   },
   "devDependencies": {
     "generate-license-file": "workspace:*",

--- a/e2e/npm-package/test/cli/__snapshots__/index.e2e.spec.ts.snap
+++ b/e2e/npm-package/test/cli/__snapshots__/index.e2e.spec.ts.snap
@@ -6,6 +6,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -91,6 +105,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`cli > for a relative path > for line ending crlf > should match snapshot when --eol is given 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -182,6 +210,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -267,6 +309,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`cli > for a relative path > no-spinner > should match snapshot when --no-spinner is given 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -358,6 +414,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four
 
 This package contains the following license:
@@ -443,6 +513,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`cli > for a relative path > should match snapshot using -i and -o 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -534,6 +618,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -619,6 +717,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`cli > for a relative path > should match snapshot with --output given before --input 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -710,6 +822,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -795,6 +921,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`cli > for an absolute path > ci > should match snapshot when --ci is given 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -886,6 +1026,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -971,6 +1125,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`cli > for an absolute path > for line ending lf > should match snapshot when --eol is given 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -1062,6 +1230,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -1147,6 +1329,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`cli > for an absolute path > omit-versions > should match snapshot when --omit-versions is given 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -1238,6 +1434,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -1323,6 +1533,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`cli > for an absolute path > should match snapshot with --input and --output wrapped in double quotes 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -1414,6 +1638,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -1499,6 +1737,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`cli > for an absolute path > should match snapshot with just --input and --output 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 

--- a/e2e/npm-package/test/library/__snapshots__/generateLicenseFile.e2e.spec.ts.snap
+++ b/e2e/npm-package/test/library/__snapshots__/generateLicenseFile.e2e.spec.ts.snap
@@ -6,6 +6,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -91,6 +105,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`generateLicenseFile > for a relative path > for line ending lf > should match snapshot 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -182,6 +210,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -270,6 +312,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -355,6 +411,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`generateLicenseFile > should omit versions when omitVersions is true 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 

--- a/e2e/npm-package/test/library/__snapshots__/getLicenseFileText.e2e.spec.ts.snap
+++ b/e2e/npm-package/test/library/__snapshots__/getLicenseFileText.e2e.spec.ts.snap
@@ -6,6 +6,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -91,6 +105,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`getLicenseFileText > for a relative path > for line ending lf > should match snapshot 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 
@@ -182,6 +210,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -270,6 +312,20 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
+ - dep-eight@1.0.0
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
+
+The following npm package may be included in this product:
+
  - dep-four@1.0.0
 
 This package contains the following license:
@@ -355,6 +411,20 @@ https://www.npmjs.com/package/generate-license-file
 exports[`getLicenseFileText > should omit versions when omitVersions is true 1`] = `
 "This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
+
+ - dep-eight
+
+This package contains the following license:
+
+# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+
+-----------
 
 The following npm package may be included in this product:
 

--- a/e2e/npm-package/test/library/__snapshots__/getProjectLicenses.e2e.spec.ts.snap
+++ b/e2e/npm-package/test/library/__snapshots__/getProjectLicenses.e2e.spec.ts.snap
@@ -3,6 +3,18 @@
 exports[`getProjectLicenses > for a relative path > should match snapshot 1`] = `
 [
   {
+    "content": "# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+",
+    "dependencies": [
+      "dep-eight@1.0.0",
+    ],
+    "notices": [],
+  },
+  {
     "content": "MIT",
     "dependencies": [
       "dep-five@1.0.0",
@@ -72,6 +84,18 @@ This license should be found.
 exports[`getProjectLicenses > for an absolute path > should match snapshot 1`] = `
 [
   {
+    "content": "# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+",
+    "dependencies": [
+      "dep-eight@1.0.0",
+    ],
+    "notices": [],
+  },
+  {
     "content": "MIT",
     "dependencies": [
       "dep-five@1.0.0",
@@ -140,6 +164,18 @@ This license should be found.
 
 exports[`getProjectLicenses > should not include versions when omitVersions is true 1`] = `
 [
+  {
+    "content": "# Dep Eight
+
+This license file is spelt \`LICENSE\`.
+This license should be found, even though a decorated variant
+(\`LICENSE-3rdparty.csv\`) also exists alongside it.
+",
+    "dependencies": [
+      "dep-eight",
+    ],
+    "notices": [],
+  },
   {
     "content": "MIT",
     "dependencies": [

--- a/e2e/test-dependencies/README.md
+++ b/e2e/test-dependencies/README.md
@@ -10,3 +10,4 @@
 | dep-five        | NO LICENSE FILE | TRUE  | The README should be used as a substitute for the license file. |
 | dep-six         | LICENSE.md      | TRUE  | Should not be used in a test bed that also uses `dep-one`       |
 | dep-seven       | LICENSE.md      | TRUE  |                                                                 |
+| dep-eight       | LICENSE         | TRUE  | Also has a `LICENSE-3rdparty.csv` file, which should not be found.  |

--- a/e2e/test-dependencies/dep-eight/LICENSE
+++ b/e2e/test-dependencies/dep-eight/LICENSE
@@ -1,0 +1,5 @@
+# Dep Eight
+
+This license file is spelt `LICENSE`.
+This license should be found, even though a decorated variant
+(`LICENSE-3rdparty.csv`) also exists alongside it.

--- a/e2e/test-dependencies/dep-eight/LICENSE-3rdparty.csv
+++ b/e2e/test-dependencies/dep-eight/LICENSE-3rdparty.csv
@@ -1,0 +1,2 @@
+name,version,license
+some-other-package,1.0.0,MIT

--- a/e2e/test-dependencies/dep-eight/README.md
+++ b/e2e/test-dependencies/dep-eight/README.md
@@ -1,0 +1,18 @@
+# Dep Eight
+
+| Test Case | LICENSE | LICENSE-3rdparty.csv |
+| --------- | ------- | --------------------- |
+| Found     | TRUE    | FALSE                 |
+
+## Notes
+
+This package has two files that match the license file pattern: `LICENSE` and
+`LICENSE-3rdparty.csv`. `LICENSE` is the correct license and should always be
+the one resolved.
+
+Globbing for license files is OS-specific: the order in which matches come
+back, and their casing, can both differ between operating systems. Without a
+deterministic way of picking between multiple matches, this package could
+resolve to a different license file depending on which OS generated the
+output. This package exists to test that the correct file, `LICENSE`, is
+always chosen regardless of OS.

--- a/e2e/test-dependencies/dep-eight/package.json
+++ b/e2e/test-dependencies/dep-eight/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "dep-eight",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/packages/generate-license-file/src/lib/internal/resolveLicenseContent/licenseFile.ts
+++ b/packages/generate-license-file/src/lib/internal/resolveLicenseContent/licenseFile.ts
@@ -23,7 +23,20 @@ export const licenseFile: Resolution = async inputs => {
     maxDepth: 1,
   });
 
-  const filteredLicenseFiles = licenseFiles.filter(file => !extensionDenyList.includes(extname(file)));
+  // glob({ nocase: true }) returns matches using the pattern's case on
+  // case-insensitive filesystems (e.g. "license" on macOS) but the on-disk
+  // case elsewhere (e.g. "LICENSE" on Linux), and in filesystem order either
+  // way. Sort case-insensitively (locale-independently, for determinism) so
+  // the chosen file and the warning are stable across platforms; the base
+  // name (e.g. "license") then sorts ahead of decorated variants
+  // (e.g. "license-3rdparty.csv"), which is usually the real license.
+  const filteredLicenseFiles = licenseFiles
+    .filter(file => !extensionDenyList.includes(extname(file)))
+    .sort((a, b) => {
+      const lowerA = a.toLowerCase();
+      const lowerB = b.toLowerCase();
+      return lowerA < lowerB ? -1 : lowerA > lowerB ? 1 : 0;
+    });
 
   if (filteredLicenseFiles.length === 0) {
     return null;

--- a/packages/generate-license-file/test/internal/resolveLicenseContent/licenseFile.spec.ts
+++ b/packages/generate-license-file/test/internal/resolveLicenseContent/licenseFile.spec.ts
@@ -51,6 +51,32 @@ describe("licenseFile", () => {
     expect(result).toBe("license contents");
   });
 
+  it("should pick the base license file over decorated variants regardless of glob's order or casing", async () => {
+    // glob({ nocase: true }) returns matches using the pattern's case on
+    // case-insensitive filesystems (macOS yields "license") but the on-disk
+    // case elsewhere (Linux yields "LICENSE"), in filesystem order either way.
+    // The real license must win over a decorated variant like
+    // "LICENSE-3rdparty.csv" on both, so the output is identical cross-platform.
+    const upperLicense = "/some/directory/LICENSE";
+    const lowerLicense = "/some/directory/license";
+    const thirdParty = "/some/directory/LICENSE-3rdparty.csv";
+
+    when(mockedReadFile).calledWith(upperLicense, { encoding: "utf-8" }).thenResolve("license contents");
+    when(mockedReadFile).calledWith(lowerLicense, { encoding: "utf-8" }).thenResolve("license contents");
+    when(mockedReadFile).calledWith(thirdParty, { encoding: "utf-8" }).thenResolve("third party contents");
+
+    // Case-sensitive filesystem (e.g. Linux): glob yields the on-disk "LICENSE"
+    mockedGlob.mockResolvedValueOnce([thirdParty, upperLicense]);
+    const caseSensitive = await licenseFile(resolutionInputs);
+
+    // Case-insensitive filesystem (e.g. macOS): glob yields the pattern's "license"
+    mockedGlob.mockResolvedValueOnce([thirdParty, lowerLicense]);
+    const caseInsensitive = await licenseFile(resolutionInputs);
+
+    expect(caseSensitive).toBe("license contents");
+    expect(caseInsensitive).toBe("license contents");
+  });
+
   it.each(
     extensionDenyList,
   )("should return null if all license files are in the extension deny list", async extension => {


### PR DESCRIPTION
## Problem

`licenseFile` picks `filteredLicenseFiles[0]` from `glob(...)`, whose match order is filesystem-dependent. With `{ nocase: true }` the casing differs too: macOS yields `license`, Linux yields `LICENSE`. So a dependency shipping multiple matches (e.g. `import-in-the-middle` ships both `LICENSE` and `LICENSE-3rdparty.csv`) can resolve to different license text on macOS vs Linux CI, breaking committed-notices drift checks.

## Fix

Sort the matches case-insensitively (locale-independently) before picking. A plain `.sort()` isn't enough: `LICENSE-3rdparty.csv` sorts ahead of lowercase `license`, so macOS would pick the CSV. Lowercasing first puts the base `license` ahead of variants like `license-3rdparty.csv` on both platforms.

```diff
-  const filteredLicenseFiles = licenseFiles.filter(file => !extensionDenyList.includes(extname(file)));
+  const filteredLicenseFiles = licenseFiles
+    .filter(file => !extensionDenyList.includes(extname(file)))
+    .sort((a, b) => {
+      const lowerA = a.toLowerCase();
+      const lowerB = b.toLowerCase();
+      return lowerA < lowerB ? -1 : lowerA > lowerB ? 1 : 0;
+    });
```

## Test

Simulates both filesystems (glob returning `LICENSE` and lowercase `license`, each alongside `LICENSE-3rdparty.csv`) and asserts both resolve to the real license.
