### PR TITLE
fix: pass maxBuffer to the pnpm licenses list call

### DIFF
--- a/packages/generate-license-file/src/lib/utils/pnpmCli.utils.ts
+++ b/packages/generate-license-file/src/lib/utils/pnpmCli.utils.ts
@@ -35,8 +35,15 @@ export const getPnpmVersion = async (): Promise<PnpmVersion> => {
   return { major, minor, patch };
 };
 
+// pnpm licenses list output can grow past exec's 1MB default maxBuffer on large
+// monorepos, so raise it to a ceiling we won't realistically hit.
+const licensesMaxBuffer = 256 * 1024 * 1024;
+
 export const getPnpmProjectDependencies = async (projectDirectory: string): Promise<PnpmDependency[]> => {
-  const { stdout } = await execAsync("pnpm licenses list --json --prod", { cwd: projectDirectory });
+  const { stdout } = await execAsync("pnpm licenses list --json --prod", {
+    cwd: projectDirectory,
+    maxBuffer: licensesMaxBuffer,
+  });
 
   const parsedOutput = JSON.parse(stdout);
   const commandOutput = pnpmLsJsonStdOutValidator.safeParse(parsedOutput);

--- a/packages/generate-license-file/test/utils/pnpmCli.utils.spec.ts
+++ b/packages/generate-license-file/test/utils/pnpmCli.utils.spec.ts
@@ -46,7 +46,18 @@ describe("pnpmCli.utils", () => {
       expect(mockedExecAsync).toHaveBeenCalledTimes(1);
       expect(mockedExecAsync).toHaveBeenCalledWith("pnpm licenses list --json --prod", {
         cwd: projectDirectory,
+        maxBuffer: 256 * 1024 * 1024,
       });
+    });
+
+    it("should not use the default exec maxBuffer, which large monorepos exceed", async () => {
+      const projectDirectory = "/path/to/project";
+      mockedExecAsync.mockResolvedValue({ stdout: "{}" } as MockExecStdOut);
+
+      await getPnpmProjectDependencies(projectDirectory);
+
+      const [, options] = mockedExecAsync.mock.calls[0];
+      expect(options?.maxBuffer).toBeGreaterThan(1024 * 1024);
     });
 
     it("should be able to handle <9.0.0 command output", async () => {


### PR DESCRIPTION
Fixes #749.

`getPnpmProjectDependencies` calls `pnpm licenses list --json --prod` via the promisified `exec` without a `maxBuffer`, so it uses Node's 1MB default. On a large pnpm monorepo the output is bigger than that and the run throws ERR_CHILD_PROCESS_STDIO_MAXBUFFER before resolving anything. The npm resolver doesn't go through exec so it's unaffected.

This sets an explicit maxBuffer on that call. I picked 256MB as a value that won't realistically be hit; happy to change the number, or switch the call to execFile/streaming instead, if you'd rather handle it differently.