### PR TITLE
fix(deps): update commander and @commander-js/extra-typings to v15

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -180,7 +180,7 @@
         "generate-license-file": "bin/generate-license-file",
       },
       "dependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
+        "@commander-js/extra-typings": "^15.0.0",
         "@npmcli/arborist": "^9.0.0",
         "cli-spinners": "^3.4.0",
         "commander": "^14.0.2",
@@ -471,7 +471,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@commander-js/extra-typings": ["@commander-js/extra-typings@14.0.0", "", { "peerDependencies": { "commander": "~14.0.0" } }, "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg=="],
+    "@commander-js/extra-typings": ["@commander-js/extra-typings@15.0.0", "", { "peerDependencies": { "commander": "~15.0.0" } }, "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA=="],
 
     "@csstools/cascade-layer-name-parser": ["@csstools/cascade-layer-name-parser@2.0.5", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-p1ko5eHgV+MgXFVa4STPKpvPxr6ReS8oS2jzTukjR74i5zJNyWO1ZM1m8YKBXnzDKWfBN1ztLYlHxbVemDD88A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -183,7 +183,7 @@
         "@commander-js/extra-typings": "^14.0.0",
         "@npmcli/arborist": "^9.0.0",
         "cli-spinners": "^3.4.0",
-        "commander": "^14.0.2",
+        "commander": "^15.0.0",
         "cosmiconfig": "^9.0.0",
         "enquirer": "^2.4.1",
         "glob": "^13.0.0",
@@ -1351,7 +1351,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
 
@@ -2960,6 +2960,8 @@
     "@babel/preset-env/babel-plugin-polyfill-corejs3": ["babel-plugin-polyfill-corejs3@0.14.2", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.8", "core-js-compat": "^3.48.0" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g=="],
 
     "@babel/preset-env/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@commander-js/extra-typings/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "@docusaurus/core/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -2974,8 +2974,6 @@
 
     "@babel/preset-env/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@commander-js/extra-typings/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
     "@docusaurus/core/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
     "@docusaurus/core/webpack-merge": ["webpack-merge@6.0.1", "", { "dependencies": { "clone-deep": "^4.0.1", "flat": "^5.0.2", "wildcard": "^2.0.1" } }, "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg=="],

--- a/packages/generate-license-file/package.json
+++ b/packages/generate-license-file/package.json
@@ -63,7 +63,7 @@
     "publish": "npm publish --access public --provenance"
   },
   "dependencies": {
-    "@commander-js/extra-typings": "^14.0.0",
+    "@commander-js/extra-typings": "^15.0.0",
     "@npmcli/arborist": "^9.0.0",
     "cli-spinners": "^3.4.0",
     "commander": "^14.0.2",

--- a/packages/generate-license-file/package.json
+++ b/packages/generate-license-file/package.json
@@ -66,7 +66,7 @@
     "@commander-js/extra-typings": "^14.0.0",
     "@npmcli/arborist": "^9.0.0",
     "cli-spinners": "^3.4.0",
-    "commander": "^14.0.2",
+    "commander": "^15.0.0",
     "cosmiconfig": "^9.0.0",
     "enquirer": "^2.4.1",
     "glob": "^13.0.0",


### PR DESCRIPTION
Combines #741 and #740 so the paired major bumps move together — `@commander-js/extra-typings@15` peer-depends on `commander@~15.0.x`, so upgrading one without the other leaves an unsatisfied peer range.

## Breaking changes reviewed (both v15 release notes)

- **ESM only** (both packages migrated CJS → ESM). Not an issue here: this package is already `"type": "module"` and builds dual CJS/ESM output via tsdown/rolldown, which bundles the ESM dependency correctly into both outputs — verified via `bun run build`.
- **Requires Node.js >= 22.12.0**. CI already runs against Node 22/24/26 (`.github/workflows/src-ci.yml`), so this is already satisfied.
- **`--no-*` negated option default behavior change** (only a *lone* `--no-*` option still implicitly defaults to `true`; defining both the positive and negative form of an option no longer does). The CLI only defines `--no-spinner` with no corresponding `--spinner` option, so it's a lone negated option and unaffected — verified via e2e test `should match snapshot when --no-spinner is given`.
- **Removed deprecated `commander/esm.mjs` export** — not imported anywhere in this repo.
- Global `program` singleton reexport change in extra-typings — not used; this repo always constructs its own `new Command()`.

## Verification

- `bun run build` / `bun run lint` / `bun run test` / `bun run test:e2e` all pass.
- Manually ran the built CLI (`node bin/generate-license-file -i package.json -o ... --ci`) and confirmed it correctly picks up `commander@15.0.0` in the generated output.
- Fixed a stray leftover `@commander-js/extra-typings/commander` lockfile override (pinned at the old v14.0.3) that the octopus merge of the two Renovate branches left behind — no longer needed now that the top-level `commander` satisfies the `~15.0.0` peer range. Verified with a clean `bun install --frozen-lockfile`.

Supersedes #741 and #740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)