### PR TITLE
fix: serve the e2e http replacement license locally

### DIFF
--- a/e2e/config-file/test/cli/replacement/config.js
+++ b/e2e/config-file/test/cli/replacement/config.js
@@ -1,3 +1,9 @@
+// The http replacement below is served by a local HTTP server which is started by
+// replacement.e2e.spec.ts. Its origin is passed in through the environment so that the
+// server can bind an ephemeral port rather than racing for a fixed one. The fallback is
+// an unused local port, so a run without the server fails fast instead of hitting the network.
+const licenseServerOrigin = process.env.GLF_E2E_LICENSE_SERVER_ORIGIN ?? "http://127.0.0.1:1";
+
 module.exports = {
   inputs: ["./package.json"],
   output: "replacement-config-output.txt",
@@ -8,7 +14,6 @@ module.exports = {
 
     "dep-three": "./some-path-that-we-dont-want-to-use.txt",
     "dep-three@1.0.0": "./name-and-version-replacement-content.txt",
-    "dep-four":
-      "https://raw.githubusercontent.com/TobyAndToby/generate-license-file/e2e/remote-license/e2e/.remote-licenses/license.md",
+    "dep-four": `${licenseServerOrigin}/license.md`,
   },
 };

--- a/e2e/config-file/test/cli/replacement/remote-license.md
+++ b/e2e/config-file/test/cli/replacement/remote-license.md
@@ -1,0 +1,7 @@
+# Remote license
+
+This file is NOT an actual license for this package.
+
+It is used as a resource for our e2e's, as a file we can fetch over the network, and have control over.
+
+This content should appear in the generated license file output!

--- a/e2e/config-file/test/cli/replacement/replacement.e2e.spec.ts
+++ b/e2e/config-file/test/cli/replacement/replacement.e2e.spec.ts
@@ -1,16 +1,49 @@
 import { exec } from "node:child_process";
 import fs from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { output as outputFileName } from "./config.js";
 
 const execAsync = promisify(exec);
 
+const licenseFixturePath = path.join(path.dirname(fileURLToPath(import.meta.url)), "remote-license.md");
+
 describe("cli", () => {
+  let server: Server;
+  let licenseServerOrigin = "";
+
+  beforeAll(async () => {
+    const licenseContent = await fs.readFile(licenseFixturePath, "utf8");
+
+    server = createServer((request, response) => {
+      if (request.url !== "/license.md") {
+        response.writeHead(404).end();
+        return;
+      }
+
+      response.writeHead(200, { "content-type": "text/markdown; charset=utf-8" }).end(licenseContent);
+    });
+
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+
+    const { port } = server.address() as AddressInfo;
+    licenseServerOrigin = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(error => (error ? reject(error) : resolve())));
+  });
+
   it("should match snapshot when a package is replaced", async () => {
     const configPath = "./test/cli/replacement/config.js";
 
-    await execAsync(`node ../../packages/generate-license-file/bin/generate-license-file -c ${configPath}`);
+    await execAsync(`node ../../packages/generate-license-file/bin/generate-license-file -c ${configPath}`, {
+      env: { ...process.env, GLF_E2E_LICENSE_SERVER_ORIGIN: licenseServerOrigin },
+    });
 
     const result = await fs.readFile(outputFileName, "utf8");
     expect(result).toMatchSnapshot();


### PR DESCRIPTION
The replacement config-file e2e fetched its `dep-four` license from raw.githubusercontent.com on every CI run (nine matrix entries per commit). When that request failed, the dependency was skipped with a warning and the snapshot lost `dep-four` — which is what the Node 22 / Ubuntu job hit.

The test now serves that license itself, so the http replacement path is still covered end to end without touching the public internet.

- Added `remote-license.md` (byte-identical to the file the old URL served) next to the test.
- `replacement.e2e.spec.ts` starts an http server on an ephemeral loopback port and serves the fixture.
- `config.js` builds the replacement URL from `GLF_E2E_LICENSE_SERVER_ORIGIN`, which the test passes to the CLI; the fallback is an unused local port so a misconfigured run fails fast rather than reaching the network.
- Snapshot unchanged. No other e2e suite makes live network calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
